### PR TITLE
[#10] Implement UI for trending list

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
@@ -17,6 +17,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp13
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp22
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp25
@@ -110,6 +111,7 @@ fun CoinItem(
                     bottom.linkTo(parent.bottom)
                     width = Dimension.preferredWrapContent
                 },
+            iconPaddingEnd = Dp13,
             isPositiveNumber = isPositiveNumber
         )
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -2,18 +2,24 @@ package co.nimblehq.compose.crypto.ui.screens.home
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp24
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp52
 import co.nimblehq.compose.crypto.ui.theme.Style
@@ -22,77 +28,131 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 @Suppress("FunctionNaming", "LongMethod")
 @Composable
 fun HomeScreen() {
+    val scrollState = rememberScrollState()
+
     Surface {
-        ConstraintLayout(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            val (
-                title,
-                portfolioCard,
-                myCoinsTitle,
-                seeAll,
-                myCoins
-            ) = createRefs()
+        BoxWithConstraints {
+            val screenHeight = maxHeight
 
-            Text(
+            Column(
                 modifier = Modifier
-                    .padding(top = Dp16)
-                    .constrainAs(title) {
-                        top.linkTo(parent.top)
-                        linkTo(start = parent.start, end = parent.end)
-                        width = Dimension.preferredWrapContent
-                    },
-                text = stringResource(id = R.string.home_title),
-                textAlign = TextAlign.Center,
-                style = Style.semiBold24(),
-                color = MaterialTheme.colors.textColor
-            )
-
-            PortfolioCard(
-                modifier = Modifier
-                    .constrainAs(portfolioCard) {
-                        top.linkTo(title.bottom, margin = Dp40)
-                    }
-                    .padding(horizontal = Dp16)
-            )
-
-            Text(
-                modifier = Modifier
-                    .constrainAs(myCoinsTitle) {
-                        top.linkTo(portfolioCard.bottom, margin = Dp52)
-                        start.linkTo(parent.start)
-                        width = Dimension.preferredWrapContent
-                    }
-                    .padding(start = Dp16),
-                text = stringResource(id = R.string.home_my_coins_title),
-                style = Style.medium16(),
-                color = MaterialTheme.colors.textColor
-            )
-
-            SeeAll(
-                modifier = Modifier
-                    .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
-                    .constrainAs(seeAll) {
-                        top.linkTo(myCoinsTitle.top)
-                        end.linkTo(parent.end)
-                        width = Dimension.preferredWrapContent
-                    }
-                    .padding(end = Dp16)
-            )
-
-            LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .constrainAs(myCoins) {
-                        top.linkTo(myCoinsTitle.bottom, margin = Dp16)
-                    },
-                contentPadding = PaddingValues(horizontal = Dp16),
-                horizontalArrangement = Arrangement.spacedBy(Dp16),
+                    .fillMaxSize()
+                    .verticalScroll(state = scrollState)
             ) {
-                // TODO: Remove dummy value when work on Integrate.
-                item { CoinItem() }
-                item { CoinItem(true) }
-                item { CoinItem() }
+                Text(
+                    modifier = Modifier
+                        .padding(top = Dp16)
+                        .align(Alignment.CenterHorizontally),
+                    text = stringResource(id = R.string.home_title),
+                    textAlign = TextAlign.Center,
+                    style = Style.semiBold24(),
+                    color = MaterialTheme.colors.textColor
+                )
+
+                PortfolioCard(modifier = Modifier.padding(start = Dp16, top = Dp40, end = Dp16))
+
+                Coins(screenHeight = screenHeight)
+            }
+        }
+    }
+}
+
+@Suppress("FunctionNaming", "LongMethod", "MagicNumber")
+@Composable
+private fun Coins(screenHeight: Dp) {
+    ConstraintLayout(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(screenHeight)
+            .padding(vertical = Dp52)
+    ) {
+
+        val (
+            myCoinsTitle,
+            seeAllMyCoins,
+            myCoins,
+            trendingTitle,
+            seeAllTrending,
+            trending
+        ) = createRefs()
+
+        Text(
+            modifier = Modifier
+                .constrainAs(myCoinsTitle) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    width = Dimension.preferredWrapContent
+
+                }
+                .padding(start = Dp16),
+            text = stringResource(id = R.string.home_my_coins_title),
+            style = Style.medium16(),
+            color = MaterialTheme.colors.textColor
+        )
+
+        SeeAll(
+            modifier = Modifier
+                .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
+                .constrainAs(seeAllMyCoins) {
+                    top.linkTo(myCoinsTitle.top)
+                    end.linkTo(parent.end)
+                    width = Dimension.preferredWrapContent
+                }
+                .padding(end = Dp16)
+        )
+
+        LazyRow(
+            modifier = Modifier
+                .constrainAs(myCoins) {
+                    top.linkTo(myCoinsTitle.bottom, margin = Dp16)
+                    start.linkTo(parent.start)
+                },
+            contentPadding = PaddingValues(horizontal = Dp16),
+            horizontalArrangement = Arrangement.spacedBy(Dp16)
+        ) {
+            // TODO: Remove dummy value when work on Integrate.
+            items(3) { index ->
+                if (index == 1) CoinItem(true) else CoinItem()
+            }
+        }
+
+        Text(
+            modifier = Modifier
+                .constrainAs(trendingTitle) {
+                    top.linkTo(myCoins.bottom, margin = Dp24)
+                    start.linkTo(parent.start)
+                    width = Dimension.preferredWrapContent
+
+                }
+                .padding(start = Dp16),
+            text = stringResource(id = R.string.home_trending_title),
+            style = Style.medium16(),
+            color = MaterialTheme.colors.textColor
+        )
+
+        SeeAll(
+            modifier = Modifier
+                .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
+                .constrainAs(seeAllTrending) {
+                    top.linkTo(trendingTitle.top)
+                    end.linkTo(parent.end)
+                    width = Dimension.preferredWrapContent
+                }
+                .padding(end = Dp16)
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .constrainAs(trending) {
+                    top.linkTo(trendingTitle.bottom, margin = Dp16)
+                    start.linkTo(parent.start)
+                }
+                .padding(horizontal = Dp16),
+            verticalArrangement = Arrangement.spacedBy(Dp16)
+        ) {
+            // TODO: Remove dummy value when work on Integrate.
+            items(4) { index ->
+                if (index == 1) TrendingItem(true) else TrendingItem()
             }
         }
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -28,8 +28,6 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 @Suppress("FunctionNaming", "LongMethod")
 @Composable
 fun HomeScreen() {
-    val scrollState = rememberScrollState()
-
     Surface {
         BoxWithConstraints {
             val screenHeight = maxHeight
@@ -37,7 +35,7 @@ fun HomeScreen() {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(state = scrollState)
+                    .verticalScroll(state = rememberScrollState())
             ) {
                 Text(
                     modifier = Modifier

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,9 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
@@ -29,27 +25,56 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 @Composable
 fun HomeScreen() {
     Surface {
-        BoxWithConstraints {
-            val screenHeight = maxHeight
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            LazyColumn {
+                item {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = Dp16),
+                        text = stringResource(id = R.string.home_title),
+                        textAlign = TextAlign.Center,
+                        style = Style.semiBold24(),
+                        color = MaterialTheme.colors.textColor
+                    )
+                }
 
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(state = rememberScrollState())
-            ) {
-                Text(
-                    modifier = Modifier
-                        .padding(top = Dp16)
-                        .align(Alignment.CenterHorizontally),
-                    text = stringResource(id = R.string.home_title),
-                    textAlign = TextAlign.Center,
-                    style = Style.semiBold24(),
-                    color = MaterialTheme.colors.textColor
-                )
+                item {
+                    PortfolioCard(
+                        modifier = Modifier.padding(start = Dp16, top = Dp40, end = Dp16)
+                    )
+                }
 
-                PortfolioCard(modifier = Modifier.padding(start = Dp16, top = Dp40, end = Dp16))
+                item { Coins() }
 
-                Coins(screenHeight = screenHeight)
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = Dp16, top = Dp24, end = Dp16, bottom = Dp16)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.home_trending_title),
+                            style = Style.medium16(),
+                            color = MaterialTheme.colors.textColor
+                        )
+
+                        SeeAll(
+                            modifier = Modifier
+                                .align(alignment = Alignment.CenterEnd)
+                                .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
+                        )
+                    }
+                }
+
+                // TODO: Remove dummy value when work on Integrate.
+                items(4) { index ->
+                    Box(modifier = Modifier.padding(start = Dp16, end = Dp16, bottom = Dp16)) {
+                        if (index == 1) TrendingItem(true) else TrendingItem()
+                    }
+                }
             }
         }
     }
@@ -57,21 +82,17 @@ fun HomeScreen() {
 
 @Suppress("FunctionNaming", "LongMethod", "MagicNumber")
 @Composable
-private fun Coins(screenHeight: Dp) {
+private fun Coins() {
     ConstraintLayout(
         modifier = Modifier
             .fillMaxWidth()
-            .height(screenHeight)
-            .padding(vertical = Dp52)
+            .padding(top = Dp52)
     ) {
 
         val (
             myCoinsTitle,
             seeAllMyCoins,
-            myCoins,
-            trendingTitle,
-            seeAllTrending,
-            trending
+            myCoins
         ) = createRefs()
 
         Text(
@@ -79,8 +100,6 @@ private fun Coins(screenHeight: Dp) {
                 .constrainAs(myCoinsTitle) {
                     top.linkTo(parent.top)
                     start.linkTo(parent.start)
-                    width = Dimension.preferredWrapContent
-
                 }
                 .padding(start = Dp16),
             text = stringResource(id = R.string.home_my_coins_title),
@@ -94,7 +113,6 @@ private fun Coins(screenHeight: Dp) {
                 .constrainAs(seeAllMyCoins) {
                     top.linkTo(myCoinsTitle.top)
                     end.linkTo(parent.end)
-                    width = Dimension.preferredWrapContent
                 }
                 .padding(end = Dp16)
         )
@@ -111,46 +129,6 @@ private fun Coins(screenHeight: Dp) {
             // TODO: Remove dummy value when work on Integrate.
             items(3) { index ->
                 if (index == 1) CoinItem(true) else CoinItem()
-            }
-        }
-
-        Text(
-            modifier = Modifier
-                .constrainAs(trendingTitle) {
-                    top.linkTo(myCoins.bottom, margin = Dp24)
-                    start.linkTo(parent.start)
-                    width = Dimension.preferredWrapContent
-
-                }
-                .padding(start = Dp16),
-            text = stringResource(id = R.string.home_trending_title),
-            style = Style.medium16(),
-            color = MaterialTheme.colors.textColor
-        )
-
-        SeeAll(
-            modifier = Modifier
-                .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
-                .constrainAs(seeAllTrending) {
-                    top.linkTo(trendingTitle.top)
-                    end.linkTo(parent.end)
-                    width = Dimension.preferredWrapContent
-                }
-                .padding(end = Dp16)
-        )
-
-        LazyColumn(
-            modifier = Modifier
-                .constrainAs(trending) {
-                    top.linkTo(trendingTitle.bottom, margin = Dp16)
-                    start.linkTo(parent.start)
-                }
-                .padding(horizontal = Dp16),
-            verticalArrangement = Arrangement.spacedBy(Dp16)
-        ) {
-            // TODO: Remove dummy value when work on Integrate.
-            items(4) { index ->
-                if (index == 1) TrendingItem(true) else TrendingItem()
             }
         }
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
@@ -1,17 +1,17 @@
 package co.nimblehq.compose.crypto.ui.screens.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -20,9 +20,9 @@ import co.nimblehq.compose.crypto.ui.theme.Color
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp0
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp13
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp20
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp4
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
 import co.nimblehq.compose.crypto.ui.theme.Style
@@ -101,11 +101,12 @@ fun PortfolioCard(
                 contentColor = Color.GuppieGreen
             ),
             shape = RoundedCornerShape(Dp20),
+            contentPadding = PaddingValues(start = Dp13, end = Dp8),
             onClick = { /* TODO */ }
         ) {
             Icon(
-                imageVector = Icons.Filled.KeyboardArrowUp,
-                modifier = Modifier.padding(end = Dp4),
+                painter = painterResource(id = R.drawable.ic_guppie_green_arrow_up),
+                modifier = Modifier.padding(end = Dp13),
                 contentDescription = null
             )
             Text(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PriceChange.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PriceChange.kt
@@ -4,31 +4,35 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.Color
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp13
 import co.nimblehq.compose.crypto.ui.theme.Style
 
 @Suppress("FunctionNaming", "LongMethod")
 @Composable
 fun PriceChange(
     modifier: Modifier,
+    iconPaddingEnd: Dp,
     isPositiveNumber: Boolean = false
 ) {
     Row(modifier = modifier) {
         Icon(
-            imageVector = if (isPositiveNumber) {
-                Icons.Filled.KeyboardArrowUp
+            modifier = Modifier
+                .padding(end = iconPaddingEnd)
+                .align(alignment = Alignment.CenterVertically),
+            painter = if (isPositiveNumber) {
+                painterResource(id = R.drawable.ic_guppie_green_arrow_up)
             } else {
-                Icons.Filled.KeyboardArrowDown
+                painterResource(id = R.drawable.ic_fire_opal_arrow_down)
             },
             tint = if (isPositiveNumber) {
                 Color.GuppieGreen
@@ -39,7 +43,6 @@ fun PriceChange(
         )
 
         Text(
-            modifier = Modifier.padding(start = Dp8),
             // TODO: Remove dummy value when work on Integrate.
             text = stringResource(R.string.coin_profit_percent, "6.21"),
             style = if (isPositiveNumber) {
@@ -57,7 +60,8 @@ fun PriceChange(
 fun PriceChangePreview() {
     ComposeTheme {
         PriceChange(
-            modifier = Modifier
+            modifier = Modifier,
+            iconPaddingEnd = Dp13
         )
     }
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PriceChange.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PriceChange.kt
@@ -1,0 +1,63 @@
+package co.nimblehq.compose.crypto.ui.screens.home
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import co.nimblehq.compose.crypto.R
+import co.nimblehq.compose.crypto.ui.theme.Color
+import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
+import co.nimblehq.compose.crypto.ui.theme.Style
+
+@Suppress("FunctionNaming", "LongMethod")
+@Composable
+fun PriceChange(
+    modifier: Modifier,
+    isPositiveNumber: Boolean = false
+) {
+    Row(modifier = modifier) {
+        Icon(
+            imageVector = if (isPositiveNumber) {
+                Icons.Filled.KeyboardArrowUp
+            } else {
+                Icons.Filled.KeyboardArrowDown
+            },
+            tint = if (isPositiveNumber) {
+                Color.GuppieGreen
+            } else {
+                Color.FireOpal
+            },
+            contentDescription = null
+        )
+
+        Text(
+            modifier = Modifier.padding(start = Dp8),
+            // TODO: Remove dummy value when work on Integrate.
+            text = stringResource(R.string.coin_profit_percent, "6.21"),
+            style = if (isPositiveNumber) {
+                Style.guppieGreenMedium16()
+            } else {
+                Style.fireOpalGreenMedium16()
+            }
+        )
+    }
+}
+
+@Suppress("FunctionNaming")
+@Composable
+@Preview
+fun PriceChangePreview() {
+    ComposeTheme {
+        PriceChange(
+            modifier = Modifier
+        )
+    }
+}

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/SeeAll.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/SeeAll.kt
@@ -27,7 +27,7 @@ fun SeeAll(
     Row(modifier = modifier) {
         Text(
             modifier = Modifier.padding(end = Dp8),
-            text = stringResource(id = R.string.home_my_coins_see_all),
+            text = stringResource(id = R.string.home_see_all),
             style = Style.tiffanyBlueMedium14()
         )
         Icon(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
@@ -16,6 +16,7 @@ import androidx.constraintlayout.compose.ConstraintLayout
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp13
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp4
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp60
@@ -93,6 +94,7 @@ fun TrendingItem(
                     bottom.linkTo(coinName.bottom)
                     width = Dimension.preferredWrapContent
                 },
+            iconPaddingEnd = Dp13,
             isPositiveNumber = isPositiveNumber
         )
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.constraintlayout.compose.Dimension
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -18,8 +17,6 @@ import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp22
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp25
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp4
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp60
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
@@ -30,12 +27,13 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 
 @Suppress("FunctionNaming", "LongMethod")
 @Composable
-fun CoinItem(
+fun TrendingItem(
     isPositiveNumber: Boolean = false /* TODO Update value to Object on Integrate ticket */
 ) {
+
     ConstraintLayout(
         modifier = Modifier
-            .wrapContentWidth()
+            .fillMaxWidth()
             .clip(RoundedCornerShape(Dp12))
             .background(color = MaterialTheme.colors.coinItemColor)
             .padding(horizontal = Dp8, vertical = Dp8)
@@ -44,7 +42,6 @@ fun CoinItem(
             logo,
             coinSymbol,
             coinName,
-            price,
             priceChange
         ) = createRefs()
 
@@ -88,26 +85,12 @@ fun CoinItem(
             style = Style.medium14()
         )
 
-        Text(
-            modifier = Modifier
-                .padding(top = Dp22)
-                .constrainAs(price) {
-                    start.linkTo(logo.start)
-                    top.linkTo(coinName.bottom)
-                    width = Dimension.preferredWrapContent
-                },
-            // TODO: Remove dummy value when work on Integrate.
-            text = stringResource(R.string.coin_currency, "24,209"),
-            color = MaterialTheme.colors.textColor,
-            style = Style.semiBold16()
-        )
-
         PriceChange(
             modifier = Modifier
-                .padding(start = Dp25)
                 .constrainAs(priceChange) {
-                    start.linkTo(price.end)
-                    bottom.linkTo(parent.bottom)
+                    end.linkTo(parent.end)
+                    top.linkTo(coinSymbol.top)
+                    bottom.linkTo(coinName.bottom)
                     width = Dimension.preferredWrapContent
                 },
             isPositiveNumber = isPositiveNumber
@@ -118,17 +101,17 @@ fun CoinItem(
 @Suppress("FunctionNaming")
 @Composable
 @Preview
-fun CoinItemPreview() {
+fun TrendingItemPreview() {
     ComposeTheme {
-        CoinItem()
+        TrendingItem()
     }
 }
 
 @Suppress("FunctionNaming")
 @Composable
 @Preview
-fun CoinItemPreviewDark() {
+fun TrendingItemPreviewDark() {
     ComposeTheme(darkTheme = true) {
-        CoinItem()
+        TrendingItem()
     }
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
@@ -8,6 +8,7 @@ object Dimension {
     val Dp4 = 4.dp
     val Dp8 = 8.dp
     val Dp12 = 12.dp
+    val Dp13 = 13.dp
     val Dp14 = 14.dp
     val Dp16 = 16.dp
     val Dp20 = 20.dp

--- a/app/src/main/res/drawable/ic_fire_opal_arrow_down.xml
+++ b/app/src/main/res/drawable/ic_fire_opal_arrow_down.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="6dp"
+    android:viewportWidth="10"
+    android:viewportHeight="6">
+    <path
+        android:fillColor="#F15950"
+        android:fillType="evenOdd"
+        android:pathData="M0.293,0.293C0.683,-0.098 1.317,-0.098 1.707,0.293L5,3.586L8.293,0.293C8.683,-0.098 9.317,-0.098 9.707,0.293C10.098,0.683 10.098,1.317 9.707,1.707L5.707,5.707C5.317,6.098 4.683,6.098 4.293,5.707L0.293,1.707C-0.098,1.317 -0.098,0.683 0.293,0.293Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_guppie_green_arrow_up.xml
+++ b/app/src/main/res/drawable/ic_guppie_green_arrow_up.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="6dp"
+    android:viewportWidth="10"
+    android:viewportHeight="6">
+    <path
+        android:fillColor="#10DC78"
+        android:fillType="evenOdd"
+        android:pathData="M9.707,5.707C9.317,6.098 8.683,6.098 8.293,5.707L5,2.414L1.707,5.707C1.317,6.098 0.683,6.098 0.293,5.707C-0.098,5.317 -0.098,4.683 0.293,4.293L4.293,0.293C4.683,-0.098 5.317,-0.098 5.707,0.293L9.707,4.293C10.098,4.683 10.098,5.317 9.707,5.707Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,8 @@
 
     <string name="home_title">Trade Now and Get\nYour Life</string>
     <string name="home_my_coins_title">My Coins 😎</string>
-    <string name="home_my_coins_see_all">see all</string>
+    <string name="home_trending_title">Trending 🔥</string>
+    <string name="home_see_all">see all</string>
 
     <string name="portfolio_card_total_coin_label">Total Coins</string>
     <string name="portfolio_card_today_profit_label">Today\'s Profit</string>


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-crypto/issues/10

## What happened 👀

- Show the following UI:
  - Header: "Trending 🔥"
  - "see all" with arrow icon
  - List of coins on vertical scrolling
- Coin item:
  - Logo
  - Coin symbol (BTC, ETH, etc.)
  - Coin name (Bitcoin, Ethereum, etc.)
  - Price
  - Price change percentage in 24h
    - Positive number: Use green color with arrow up `#10DC78`
    - Negative number: Use red color with arrow down `#F15950`
- Display adaptive in light/dark mode

## Insight 📝

- Create `TrendingItem` to show the trending section of coins.
- Create `PriceChange` to make it reusable in `TrendingItem` and `CoinItem`.

## Proof Of Work 📹

https://user-images.githubusercontent.com/28002315/187388408-e13065b2-9dfe-4703-87a7-fbe702a9665f.mov
