### PR TITLE
[#3] [UI] As a user, I can switch between light/dark mode base on System settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,8 +142,6 @@ dependencies {
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-ui-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
 
-    implementation("com.google.android.material:material:${Versions.MATERIAL_VERSION}")
-
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")
 
     implementation("com.google.firebase:firebase-bom:${Versions.FIREBASE_BOM_VERSION}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,7 +137,6 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:${Versions.COMPOSE_VERSION}")
     implementation("androidx.compose.foundation:foundation:${Versions.COMPOSE_VERSION}")
     implementation("androidx.compose.material:material:${Versions.COMPOSE_VERSION}")
-    implementation("com.google.accompanist:accompanist-systemuicontroller:${Versions.COMPOSE_ACCOMPANIST_VERSION}")
 
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,8 @@ dependencies {
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-ui-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
 
+    implementation("com.google.android.material:material:${Versions.MATERIAL_VERSION}")
+
     implementation("com.google.dagger:hilt-android:${Versions.HILT_VERSION}")
 
     implementation("com.google.firebase:firebase-bom:${Versions.FIREBASE_BOM_VERSION}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview:${Versions.COMPOSE_VERSION}")
     implementation("androidx.compose.foundation:foundation:${Versions.COMPOSE_VERSION}")
     implementation("androidx.compose.material:material:${Versions.COMPOSE_VERSION}")
+    implementation("com.google.accompanist:accompanist-systemuicontroller:${Versions.COMPOSE_ACCOMPANIST_VERSION}")
 
     implementation("androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")
     implementation("androidx.navigation:navigation-runtime-ktx:${Versions.ANDROIDX_NAVIGATION_VERSION}")

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/MainActivity.kt
@@ -3,6 +3,7 @@ package co.nimblehq.compose.crypto.ui.screens
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import co.nimblehq.compose.crypto.ui.screens.home.HomeScreen
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -13,6 +14,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             ComposeTheme {
                 HomeScreen()

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -67,7 +67,9 @@ private fun HomeScreenContent(
 ) {
     Surface {
         Column(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .systemBarsPadding()
         ) {
             LazyColumn {
                 item {

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.graphics.Color
 
 @Suppress("MagicNumber")
 object Color {
-    val BlueFreeSpeech = Color(0xFF3F51B5)
     val Guyabano = Color(0xFFF8F8F8)
     val MetallicSeaweed = Color(0xFF028090)
     val TiffanyBlue = Color(0xFF00BFB2)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.graphics.Color
 @Suppress("MagicNumber")
 object Color {
     val BlueFreeSpeech = Color(0xFF3F51B5)
-    val White = Color.White
+    val AlmostWhite = Color(0xFFF8F8F8)
     val MetallicSeaweed = Color(0xFF028090)
     val TiffanyBlue = Color(0xFF00BFB2)
     val Water = Color(0xFFD6F5F3)
@@ -14,7 +14,6 @@ object Color {
     val LightSilver = Color(0xFFD6D7D8)
     val Quartz = Color(0xFF484D58)
     val QuartzAlpha20 = Quartz.copy(alpha = 0.2f)
-    val Cultured = Color(0xFFEEEEEE)
     val FireOpal = Color(0xFFF15950)
     val SonicSilver = Color(0xFF70747C)
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.graphics.Color
 @Suppress("MagicNumber")
 object Color {
     val BlueFreeSpeech = Color(0xFF3F51B5)
-    val AlmostWhite = Color(0xFFF8F8F8)
+    val Guyabano = Color(0xFFF8F8F8)
     val MetallicSeaweed = Color(0xFF028090)
     val TiffanyBlue = Color(0xFF00BFB2)
     val Water = Color(0xFFD6F5F3)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
@@ -3,11 +3,9 @@ package co.nimblehq.compose.crypto.ui.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import co.nimblehq.compose.crypto.ui.theme.Color.BlueFreeSpeech
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
 import co.nimblehq.compose.crypto.ui.theme.Color.Guyabano
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Suppress("MatchingDeclarationName")
 object Palette {
@@ -31,16 +29,6 @@ fun ComposeTheme(
         Palette.ComposeDarkPalette
     } else {
         Palette.ComposeLightPalette
-    }
-
-    val systemUiController = rememberSystemUiController()
-    DisposableEffect(systemUiController, darkTheme) {
-        systemUiController.setSystemBarsColor(
-            color = colors.surface,
-            darkIcons = !darkTheme
-        )
-
-        onDispose { }
     }
 
     MaterialTheme(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
@@ -3,14 +3,12 @@ package co.nimblehq.compose.crypto.ui.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import co.nimblehq.compose.crypto.ui.theme.Color.BlueFreeSpeech
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
 import co.nimblehq.compose.crypto.ui.theme.Color.Guyabano
 
 @Suppress("MatchingDeclarationName")
 object Palette {
     val ComposeLightPalette = lightColors(
-        primary = BlueFreeSpeech,
         surface = Guyabano,
     )
 

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
@@ -4,16 +4,16 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import co.nimblehq.compose.crypto.ui.theme.Color.AlmostWhite
 import co.nimblehq.compose.crypto.ui.theme.Color.BlueFreeSpeech
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
+import co.nimblehq.compose.crypto.ui.theme.Color.Guyabano
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Suppress("MatchingDeclarationName")
 object Palette {
     val ComposeLightPalette = lightColors(
         primary = BlueFreeSpeech,
-        surface = AlmostWhite,
+        surface = Guyabano,
     )
 
     val ComposeDarkPalette = darkColors(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Theme.kt
@@ -1,19 +1,19 @@
 package co.nimblehq.compose.crypto.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
-import co.nimblehq.compose.crypto.ui.theme.Color.Cultured
+import androidx.compose.runtime.DisposableEffect
+import co.nimblehq.compose.crypto.ui.theme.Color.AlmostWhite
 import co.nimblehq.compose.crypto.ui.theme.Color.BlueFreeSpeech
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Suppress("MatchingDeclarationName")
 object Palette {
     val ComposeLightPalette = lightColors(
         primary = BlueFreeSpeech,
-        surface = Cultured
+        surface = AlmostWhite,
     )
 
     val ComposeDarkPalette = darkColors(
@@ -31,6 +31,16 @@ fun ComposeTheme(
         Palette.ComposeDarkPalette
     } else {
         Palette.ComposeLightPalette
+    }
+
+    val systemUiController = rememberSystemUiController()
+    DisposableEffect(systemUiController, darkTheme) {
+        systemUiController.setSystemBarsColor(
+            color = colors.surface,
+            darkIcons = !darkTheme
+        )
+
+        onDispose { }
     }
 
     MaterialTheme(

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/bools.xml
+++ b/app/src/main/res/values-night/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="windowLightStatusBar">false</bool>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Declaring colors for using in themes/UI component attributes with a meaningful name -->
-    <color name="colorBackground">@color/almost_white</color>
+    <color name="colorBackground">@color/dark_jungle_green</color>
 </resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="windowLightStatusBar">true</bool>
+</resources>

--- a/app/src/main/res/values/colors_pallete.xml
+++ b/app/src/main/res/values/colors_pallete.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Declaring colors with their real name from the style guide we get -->
-    <color name="blue_free_speech">#3F51B5</color>
-    <color name="blue_tory">#303F9F</color>
-    <color name="red_violet">#FF4081</color>
+    <color name="almost_white">#FFF8F8F8</color>
+    <color name="dark_jungle_green">#FF141B29</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <resources>
-    <string name="app_name">Cryto Compose</string>
+    <string name="app_name">Crypto Compose</string>
     <string name="error_generic">Unexpected error</string>
 
     <string name="home_title">Trade Now and Get\nYour Life</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,11 +1,11 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowBackground">@color/colorBackground</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightStatusBar</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowBackground">@color/colorBackground</item>

--- a/app/src/staging/res/values/strings.xml
+++ b/app/src/staging/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Cryto Compose - Staging</string>
+    <string name="app_name">Crypto Compose - Staging</string>
 </resources>

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,9 +1,9 @@
 object Versions {
     const val BUILD_GRADLE_VERSION = "7.0.4"
 
-    const val ANDROID_COMPILE_SDK_VERSION = 31
+    const val ANDROID_COMPILE_SDK_VERSION = 32
     const val ANDROID_MIN_SDK_VERSION = 23
-    const val ANDROID_TARGET_SDK_VERSION = 31
+    const val ANDROID_TARGET_SDK_VERSION = 32
 
     const val ANDROID_VERSION_CODE = 2
     const val ANDROID_VERSION_NAME = "0.2.0"
@@ -18,8 +18,7 @@ object Versions {
     const val ANDROIDX_NAVIGATION_VERSION = "2.3.4"
     const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
 
-    const val COMPOSE_VERSION = "1.0.2"
-    const val COMPOSE_ACCOMPANIST_VERSION = "0.20.3"
+    const val COMPOSE_VERSION = "1.2.0-rc01"
     const val COMPOSE_ACTIVITY_VERSION = "1.3.1"
     const val COMPOSE_CONSTRAINT_LAYOUT_VERSION = "1.0.1"
     const val CONSTRAINT_LAYOUT_VERSION = "2.0.0-alpha3"
@@ -34,9 +33,9 @@ object Versions {
     const val JAVAX_INJECT_VERSION = "1"
     const val JACOCO_VERSION = "0.8.7"
 
-    const val KOTLIN_REFLECT_VERSION = "1.5.10"
-    const val KOTLIN_VERSION = "1.5.21"
-    const val KOTLINX_COROUTINES_VERSION = "1.5.0"
+    const val KOTLIN_REFLECT_VERSION = "1.6.21"
+    const val KOTLIN_VERSION = "1.6.21"
+    const val KOTLINX_COROUTINES_VERSION = "1.6.4"
 
     const val MATERIAL_VERSION = "1.6.0"
     const val MOSHI_VERSION = "1.12.0"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -38,6 +38,7 @@ object Versions {
     const val KOTLIN_VERSION = "1.5.21"
     const val KOTLINX_COROUTINES_VERSION = "1.5.0"
 
+    const val MATERIAL_VERSION = "1.6.0"
     const val MOSHI_VERSION = "1.12.0"
 
     const val OKHTTP_VERSION = "4.9.1"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -37,7 +37,6 @@ object Versions {
     const val KOTLIN_VERSION = "1.6.21"
     const val KOTLINX_COROUTINES_VERSION = "1.6.4"
 
-    const val MATERIAL_VERSION = "1.6.0"
     const val MOSHI_VERSION = "1.12.0"
 
     const val OKHTTP_VERSION = "4.9.1"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -19,6 +19,7 @@ object Versions {
     const val ANDROIDX_SUPPORT_VERSION = "1.3.0"
 
     const val COMPOSE_VERSION = "1.0.2"
+    const val COMPOSE_ACCOMPANIST_VERSION = "0.20.3"
     const val COMPOSE_ACTIVITY_VERSION = "1.3.1"
     const val COMPOSE_CONSTRAINT_LAYOUT_VERSION = "1.0.1"
     const val CONSTRAINT_LAYOUT_VERSION = "2.0.0-alpha3"


### PR DESCRIPTION
Resolves https://github.com/nimblehq/jetpack-compose-crypto/issues/3

## What happened 👀

- Set dark/light background and status bar colors for `Compose`.
  - use `accompanist-systemuicontroller` to `systemUiController.setSystemBarsColor`.
- Set dark/light background and status bar colors for `base wrapper activity`.
  - `material` 1.6.0 requires API 31 and Gradle 7.
- Correct app name and remove unused layout.

## Insight 📝

N/A

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/188708295-95fabc3a-2dea-4f1d-ae60-733e70b349b9.mp4


https://user-images.githubusercontent.com/16315358/188708333-35b2a664-ffe9-48cd-82ed-2e9a7caccc7d.mp4

