### PR TITLE
[#33] As a user, I can see the coin image fit circular and crop in center

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
@@ -2,8 +2,12 @@ package co.nimblehq.compose.crypto.ui.screens.home
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
-import androidx.compose.foundation.*
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -21,11 +25,11 @@ import co.nimblehq.compose.crypto.ui.common.price.PriceChange
 import co.nimblehq.compose.crypto.ui.preview.CoinItemPreviewParameterProvider
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp14
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp22
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp25
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp4
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp60
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
 import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.coinItemColor
@@ -45,7 +49,7 @@ fun CoinItem(
             .clip(RoundedCornerShape(Dp12))
             .clickable { onMyCoinsItemClick.invoke() }
             .background(color = MaterialTheme.colors.coinItemColor)
-            .padding(horizontal = Dp8, vertical = Dp8)
+            .padding(Dp8)
     ) {
         val (
             logo,
@@ -57,11 +61,10 @@ fun CoinItem(
 
         Image(
             modifier = Modifier
-                .size(Dp60)
-                .padding(end = Dp16)
+                .size(Dp40)
                 .constrainAs(logo) {
-                    top.linkTo(coinSymbol.top)
-                    bottom.linkTo(coinName.bottom)
+                    top.linkTo(anchor = coinSymbol.top, margin = Dp8)
+                    bottom.linkTo(anchor = coinName.bottom, margin = Dp8)
                     start.linkTo(parent.start)
                 },
             painter = rememberAsyncImagePainter(coinItem.image),
@@ -72,7 +75,7 @@ fun CoinItem(
             modifier = Modifier
                 .constrainAs(coinSymbol) {
                     top.linkTo(parent.top)
-                    start.linkTo(logo.end)
+                    start.linkTo(anchor = logo.end, margin = Dp16)
                 },
             text = coinItem.symbol.uppercase(),
             color = MaterialTheme.colors.textColor,
@@ -94,10 +97,9 @@ fun CoinItem(
 
         Text(
             modifier = Modifier
-                .padding(top = Dp22)
                 .constrainAs(price) {
                     start.linkTo(logo.start)
-                    top.linkTo(coinName.bottom)
+                    top.linkTo(anchor = coinName.bottom, margin = Dp14)
                     width = Dimension.preferredWrapContent
                 },
             text = stringResource(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
@@ -4,7 +4,9 @@ import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -20,7 +22,8 @@ import co.nimblehq.compose.crypto.ui.preview.CoinItemPreviewParameterProvider
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
-import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp60
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp6
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
 import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.coinItemColor
@@ -39,7 +42,7 @@ fun TrendingItem(
             .fillMaxWidth()
             .clip(RoundedCornerShape(Dp12))
             .background(color = MaterialTheme.colors.coinItemColor)
-            .padding(horizontal = Dp8, vertical = Dp8)
+            .padding(Dp8)
     ) {
         val (
             logo,
@@ -50,10 +53,14 @@ fun TrendingItem(
 
         Image(
             modifier = Modifier
-                .size(Dp60)
-                .padding(end = Dp16)
+                .size(Dp40)
                 .constrainAs(logo) {
-                    linkTo(top = parent.top, bottom = parent.bottom)
+                    linkTo(
+                        top = parent.top,
+                        bottom = parent.bottom,
+                        topMargin = Dp6,
+                        bottomMargin = Dp6
+                    )
                     start.linkTo(parent.start)
                 },
             painter = rememberAsyncImagePainter(coinItem.image),
@@ -65,7 +72,7 @@ fun TrendingItem(
                 .constrainAs(coinSymbol) {
                     top.linkTo(parent.top)
                     bottom.linkTo(coinName.top)
-                    start.linkTo(logo.end)
+                    start.linkTo(anchor = logo.end, margin = Dp16)
                 },
             text = coinItem.symbol.uppercase(),
             color = MaterialTheme.colors.textColor,

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.dp
 object Dimension {
     val Dp0 = 0.dp
     val Dp4 = 4.dp
+    val Dp6 = 6.dp
     val Dp8 = 8.dp
     val Dp9 = 9.dp
     val Dp12 = 12.dp


### PR DESCRIPTION
Close #33 

## What happened 👀

The coin images return from API in different styles (circular, square, transparent background, etc.), the coin images are displaying inconsistency on my coins and trending coins.

## Insight 📝

- As the result of updating the coin image with circular and background color, the team agree to keep the old one.

<img src="https://user-images.githubusercontent.com/6950766/189878044-8d74367e-468d-4769-9978-826b3a0dc20f.png" width=300 />

<img src="https://user-images.githubusercontent.com/6950766/189878070-f79ea45a-9ac7-4448-81e3-205e313bbb26.png" width=300 />

- Update the image size and margin according to design on Figma

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/189879140-dac5757b-d0d0-4215-a1ee-61207cb2641a.mp4
