### PR TITLE
[#20][Integrate] As a user, I can see the chart of coin prices

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
@@ -24,10 +24,13 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import co.nimblehq.compose.crypto.R
+import co.nimblehq.compose.crypto.data.extension.orZero
+import co.nimblehq.compose.crypto.domain.model.CoinPrice
 import co.nimblehq.compose.crypto.extension.toFormattedString
 import co.nimblehq.compose.crypto.lib.IsLoading
 import co.nimblehq.compose.crypto.ui.common.price.PriceChangeButton
 import co.nimblehq.compose.crypto.ui.components.chartintervals.ChartIntervalsButtonGroup
+import co.nimblehq.compose.crypto.ui.components.chartintervals.TimeIntervals
 import co.nimblehq.compose.crypto.ui.components.linechart.CoinPriceChart
 import co.nimblehq.compose.crypto.ui.components.linechart.CoinPriceLabelDrawer
 import co.nimblehq.compose.crypto.ui.navigation.AppDestination
@@ -51,7 +54,6 @@ import me.bytebeats.views.charts.line.render.line.GradientLineShader
 import me.bytebeats.views.charts.line.render.line.SolidLineDrawer
 import me.bytebeats.views.charts.line.render.point.EmptyPointDrawer
 import me.bytebeats.views.charts.simpleChartAnimation
-import kotlin.random.Random
 
 @Composable
 fun DetailScreen(
@@ -71,11 +73,16 @@ fun DetailScreen(
     }
 
     val coinDetailUiModel: CoinDetailUiModel? by viewModel.output.coinDetailUiModel.collectAsState()
+    val coinPrices: List<CoinPrice> by viewModel.output.coinPrices.collectAsState()
     val showLoading: IsLoading by viewModel.showLoading.collectAsState()
 
     DetailScreenContent(
         coinDetailUiModel = coinDetailUiModel,
+        coinPrices = coinPrices,
         onBackIconClick = { navigator(AppDestination.Up) },
+        onTimeIntervalsChanged = { timeIntervals ->
+            viewModel.getCoinPrices(coinId = coinId, timeIntervals)
+        },
         showLoading = showLoading
     )
 
@@ -84,16 +91,16 @@ fun DetailScreen(
     }
 }
 
-@Suppress("MagicNumber")
 @Composable
 private fun DetailScreenContent(
     coinDetailUiModel: CoinDetailUiModel?,
+    coinPrices: List<CoinPrice>,
     onBackIconClick: () -> Unit,
+    onTimeIntervalsChanged: (TimeIntervals) -> Unit,
     showLoading: Boolean
 ) {
     val localDensity = LocalDensity.current
     val sellBuyLayoutHeight = remember { mutableStateOf(Dp0) }
-    val context = LocalContext.current
 
     Surface {
         ConstraintLayout(
@@ -163,16 +170,6 @@ private fun DetailScreenContent(
                     displayForDetailPage = true
                 )
 
-                // TODO: Update this section when work create UI for a graph.
-                val mockData = mutableListOf<LineChartData.Point>()
-                for (i in 1..10) {
-                    mockData.add(
-                        LineChartData.Point(
-                            Random.nextInt(18000, 30000).toFloat(),
-                            stringResource(R.string.coin_currency, "3,260.62")
-                        )
-                    )
-                }
                 CoinPriceChart(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -182,7 +179,13 @@ private fun DetailScreenContent(
                             end.linkTo(parent.end)
                         },
                     lineChartData = LineChartData(
-                        points = mockData
+                        points = coinPrices.map { coinPrice ->
+                            val price = stringResource(
+                                R.string.coin_currency,
+                                coinPrice.price.toFormattedString()
+                            )
+                            LineChartData.Point(coinPrice.price.orZero().toFloat(), price)
+                        }
                     ),
                     animation = simpleChartAnimation(),
                     pointDrawer = EmptyPointDrawer,
@@ -206,12 +209,7 @@ private fun DetailScreenContent(
                         end.linkTo(parent.end)
                     },
                     onIntervalChanged = { timeIntervals ->
-                        // TODO Refresh the chart on time interval changed
-                        Toast.makeText(
-                            context,
-                            "Time interval changed: $timeIntervals",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        onTimeIntervalsChanged.invoke(timeIntervals)
                     }
                 )
 
@@ -222,6 +220,20 @@ private fun DetailScreenContent(
                     sellBuyLayoutHeight = sellBuyLayoutHeight.value,
                     coinDetailUiModel = coinDetailUiModel
                 )
+
+                if (showLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .constrainAs(progressIndicator) {
+                                linkTo(
+                                    start = parent.start,
+                                    end = parent.end,
+                                    top = parent.top,
+                                    bottom = parent.bottom
+                                )
+                            },
+                    )
+                }
             }
 
             if (showLoading) {
@@ -294,7 +306,9 @@ fun DetailScreenPreview(
     ComposeTheme {
         DetailScreenContent(
             coinDetailUiModel = params.detail,
+            coinPrices = emptyList(),
             onBackIconClick = {},
+            onTimeIntervalsChanged = {},
             showLoading = params.showLoading
         )
     }
@@ -308,7 +322,9 @@ fun DetailScreenPreviewDark(
     ComposeTheme {
         DetailScreenContent(
             coinDetailUiModel = params.detail,
+            coinPrices = emptyList(),
             onBackIconClick = {},
+            onTimeIntervalsChanged = {},
             showLoading = params.showLoading
         )
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
@@ -91,6 +91,7 @@ fun DetailScreen(
     }
 }
 
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun DetailScreenContent(
     coinDetailUiModel: CoinDetailUiModel?,

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailScreen.kt
@@ -209,9 +209,7 @@ private fun DetailScreenContent(
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
                     },
-                    onIntervalChanged = { timeIntervals ->
-                        onTimeIntervalsChanged.invoke(timeIntervals)
-                    }
+                    onIntervalChanged = onTimeIntervalsChanged::invoke
                 )
 
                 CoinInfo(
@@ -221,20 +219,6 @@ private fun DetailScreenContent(
                     sellBuyLayoutHeight = sellBuyLayoutHeight.value,
                     coinDetailUiModel = coinDetailUiModel
                 )
-
-                if (showLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier
-                            .constrainAs(progressIndicator) {
-                                linkTo(
-                                    start = parent.start,
-                                    end = parent.end,
-                                    top = parent.top,
-                                    bottom = parent.bottom
-                                )
-                            },
-                    )
-                }
             }
 
             if (showLoading) {

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
@@ -1,13 +1,24 @@
 package co.nimblehq.compose.crypto.ui.screens.detail
 
+import co.nimblehq.compose.crypto.domain.model.CoinPrice
 import co.nimblehq.compose.crypto.domain.usecase.GetCoinDetailUseCase
-import co.nimblehq.compose.crypto.ui.base.*
+import co.nimblehq.compose.crypto.domain.usecase.GetCoinPricesUseCase
+import co.nimblehq.compose.crypto.ui.base.BaseInput
+import co.nimblehq.compose.crypto.ui.base.BaseOutput
+import co.nimblehq.compose.crypto.ui.base.BaseViewModel
+import co.nimblehq.compose.crypto.ui.components.chartintervals.TimeIntervals
 import co.nimblehq.compose.crypto.ui.uimodel.CoinDetailUiModel
 import co.nimblehq.compose.crypto.ui.uimodel.toUiModel
 import co.nimblehq.compose.crypto.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.filterNot
+import java.util.*
 import javax.inject.Inject
+
+private const val COIN_PRICES_CURRENCY = "usd"
 
 interface Input : BaseInput {
 
@@ -17,12 +28,14 @@ interface Input : BaseInput {
 interface Output : BaseOutput {
 
     val coinDetailUiModel: StateFlow<CoinDetailUiModel?>
+    val coinPrices: StateFlow<List<CoinPrice>>
 }
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
     dispatchers: DispatchersProvider,
-    private val getCoinDetailUseCase: GetCoinDetailUseCase
+    private val getCoinDetailUseCase: GetCoinDetailUseCase,
+    private val getCoinPricesUseCase: GetCoinPricesUseCase
 ) : BaseViewModel(dispatchers), Input, Output {
 
     override val input = this
@@ -32,19 +45,66 @@ class DetailViewModel @Inject constructor(
     override val coinDetailUiModel: StateFlow<CoinDetailUiModel?>
         get() = _coinDetailUiModel
 
+    private val _coinPrices = MutableStateFlow<List<CoinPrice>>(emptyList())
+    override val coinPrices: StateFlow<List<CoinPrice>>
+        get() = _coinPrices
+
     override fun getCoinId(coinId: String) {
         getCoinDetail(coinId = coinId)
+        getCoinPrices(coinId = coinId)
     }
 
     private fun getCoinDetail(coinId: String) = execute {
         showLoading()
         getCoinDetailUseCase.execute(coinId = coinId)
             .catch { e ->
+                hideLoading()
                 _error.emit(e)
             }
             .collect { coinDetail ->
+                hideLoading()
                 _coinDetailUiModel.emit(coinDetail.toUiModel())
             }
         hideLoading()
     }
+
+    fun getCoinPrices(coinId: String, timeIntervals: TimeIntervals = TimeIntervals.ONE_DAY) =
+        execute {
+            val calendar = Calendar.getInstance()
+            val fromTimestamp = when (timeIntervals) {
+                TimeIntervals.ONE_DAY -> calendar.apply {
+                    add(Calendar.DAY_OF_YEAR, -1)
+                }
+                TimeIntervals.ONE_WEEK -> calendar.apply {
+                    add(Calendar.DAY_OF_YEAR, -7)
+                }
+                TimeIntervals.ONE_MONTH -> calendar.apply {
+                    add(Calendar.MONTH, -1)
+                }
+                TimeIntervals.ONE_YEAR -> calendar.apply {
+                    add(Calendar.YEAR, -1)
+                }
+                TimeIntervals.FIVE_YEAR -> calendar.apply {
+                    add(Calendar.YEAR, -5)
+                }
+            }
+
+            showLoading()
+            getCoinPricesUseCase.execute(
+                GetCoinPricesUseCase.Input(
+                    coinId = coinId,
+                    currency = COIN_PRICES_CURRENCY,
+                    fromTimestamp = fromTimestamp.timeInMillis.div(1000),
+                    toTimestamp = Calendar.getInstance().timeInMillis.div(1000)
+                )
+            ).catch { e ->
+                hideLoading()
+                _error.emit(e)
+            }.filterNot {
+                it.isEmpty()
+            }.collect { coinPrices ->
+                hideLoading()
+                _coinPrices.emit(coinPrices)
+            }
+        }
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
@@ -68,6 +68,7 @@ class DetailViewModel @Inject constructor(
         hideLoading()
     }
 
+    @Suppress("MagicNumber")
     fun getCoinPrices(coinId: String, timeIntervals: TimeIntervals = TimeIntervals.ONE_DAY) =
         execute {
             val calendar = Calendar.getInstance()

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModel.kt
@@ -7,6 +7,7 @@ import co.nimblehq.compose.crypto.ui.base.BaseInput
 import co.nimblehq.compose.crypto.ui.base.BaseOutput
 import co.nimblehq.compose.crypto.ui.base.BaseViewModel
 import co.nimblehq.compose.crypto.ui.components.chartintervals.TimeIntervals
+import co.nimblehq.compose.crypto.ui.screens.home.FIAT_CURRENCY
 import co.nimblehq.compose.crypto.ui.uimodel.CoinDetailUiModel
 import co.nimblehq.compose.crypto.ui.uimodel.toUiModel
 import co.nimblehq.compose.crypto.util.DispatchersProvider
@@ -17,8 +18,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNot
 import java.util.*
 import javax.inject.Inject
-
-private const val COIN_PRICES_CURRENCY = "usd"
 
 interface Input : BaseInput {
 
@@ -58,11 +57,9 @@ class DetailViewModel @Inject constructor(
         showLoading()
         getCoinDetailUseCase.execute(coinId = coinId)
             .catch { e ->
-                hideLoading()
                 _error.emit(e)
             }
             .collect { coinDetail ->
-                hideLoading()
                 _coinDetailUiModel.emit(coinDetail.toUiModel())
             }
         hideLoading()
@@ -71,22 +68,13 @@ class DetailViewModel @Inject constructor(
     @Suppress("MagicNumber")
     fun getCoinPrices(coinId: String, timeIntervals: TimeIntervals = TimeIntervals.ONE_DAY) =
         execute {
-            val calendar = Calendar.getInstance()
-            val fromTimestamp = when (timeIntervals) {
-                TimeIntervals.ONE_DAY -> calendar.apply {
-                    add(Calendar.DAY_OF_YEAR, -1)
-                }
-                TimeIntervals.ONE_WEEK -> calendar.apply {
-                    add(Calendar.DAY_OF_YEAR, -7)
-                }
-                TimeIntervals.ONE_MONTH -> calendar.apply {
-                    add(Calendar.MONTH, -1)
-                }
-                TimeIntervals.ONE_YEAR -> calendar.apply {
-                    add(Calendar.YEAR, -1)
-                }
-                TimeIntervals.FIVE_YEAR -> calendar.apply {
-                    add(Calendar.YEAR, -5)
+            val fromTimestamp = Calendar.getInstance().apply {
+                when (timeIntervals) {
+                    TimeIntervals.ONE_DAY -> add(Calendar.DAY_OF_YEAR, -1)
+                    TimeIntervals.ONE_WEEK -> add(Calendar.DAY_OF_YEAR, -7)
+                    TimeIntervals.ONE_MONTH -> add(Calendar.MONTH, -1)
+                    TimeIntervals.ONE_YEAR -> add(Calendar.YEAR, -1)
+                    TimeIntervals.FIVE_YEAR -> add(Calendar.YEAR, -5)
                 }
             }
 
@@ -94,18 +82,17 @@ class DetailViewModel @Inject constructor(
             getCoinPricesUseCase.execute(
                 GetCoinPricesUseCase.Input(
                     coinId = coinId,
-                    currency = COIN_PRICES_CURRENCY,
+                    currency = FIAT_CURRENCY,
                     fromTimestamp = fromTimestamp.timeInMillis.div(1000),
                     toTimestamp = Calendar.getInstance().timeInMillis.div(1000)
                 )
             ).catch { e ->
-                hideLoading()
                 _error.emit(e)
             }.filterNot {
                 it.isEmpty()
             }.collect { coinPrices ->
-                hideLoading()
                 _coinPrices.emit(coinPrices)
             }
+            hideLoading()
         }
 }

--- a/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/detail/DetailViewModelTest.kt
@@ -2,6 +2,7 @@ package co.nimblehq.compose.crypto.ui.screens.detail
 
 import app.cash.turbine.test
 import co.nimblehq.compose.crypto.domain.usecase.GetCoinDetailUseCase
+import co.nimblehq.compose.crypto.domain.usecase.GetCoinPricesUseCase
 import co.nimblehq.compose.crypto.test.MockUtil
 import co.nimblehq.compose.crypto.ui.screens.BaseViewModelTest
 import co.nimblehq.compose.crypto.ui.uimodel.toUiModel
@@ -14,17 +15,21 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
 
 @ExperimentalCoroutinesApi
 class DetailViewModelTest : BaseViewModelTest() {
 
     private val mockGetCoinDetailUseCase = mockk<GetCoinDetailUseCase>()
+    private val mockGetCoinPricesUseCase = mockk<GetCoinPricesUseCase>()
     private lateinit var viewModel: DetailViewModel
 
     @Before
     fun setUp() {
         every { mockGetCoinDetailUseCase.execute(any()) } returns flowOf(MockUtil.coinDetail)
+        every { mockGetCoinPricesUseCase.execute(any()) } returns flowOf(emptyList())
 
         Dispatchers.setMain(testDispatcher)
     }
@@ -69,7 +74,8 @@ class DetailViewModelTest : BaseViewModelTest() {
     private fun initViewModel() {
         viewModel = DetailViewModel(
             testDispatcherProvider,
-            mockGetCoinDetailUseCase
+            mockGetCoinDetailUseCase,
+            mockGetCoinPricesUseCase
         )
     }
 }


### PR DESCRIPTION
Closes #20

## What happened 👀

The user is able to see the chart of coin prices on the detail page

- Show the highest/lowest price on the chart
- When the user selects a new time set, refresh the chart by fetching new data from API

## Insight 📝

- Map coin prices to show on the chart
- *Known issue*: The chart rendering is quite slow on 1M, 1Y, 5Y due to the long list of coin prices. The lowest andhighest coin prices are being cut off on the screen bound.

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/195017757-6f5cb225-caa8-463a-bf24-9c596f403c7e.mp4