### PR TITLE
[#22] [#52] Added BoxShadow in PortfolioCard in HomeScreen

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/extension/BoxShadow.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/extension/BoxShadow.kt
@@ -1,0 +1,53 @@
+package co.nimblehq.compose.crypto.extension
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+fun Modifier.boxShadow(color: Color = Color.Black,
+                               borderRadius: Dp = 0.dp,
+                               blurRadius: Dp = 0.dp,
+                               offsetY: Dp = 0.dp,
+                               offsetX: Dp = 0.dp,
+                               spread: Float = 0f,
+                               modifier: Modifier = Modifier,
+) = this.then(
+    modifier.drawBehind {
+        this.drawIntoCanvas {
+            val paint = Paint()
+            val frameworkPaint = paint.asFrameworkPaint()
+            val spreadPixel = spread.dp.toPx()
+            val leftPixel = (0f - spreadPixel) + offsetX.toPx()
+            val topPixel = (0f - spreadPixel) + offsetY.toPx()
+            val rightPixel = (this.size.width + spreadPixel)
+            val bottomPixel =  (this.size.height + spreadPixel)
+
+
+            if (blurRadius != 0.dp) {
+                /*
+                    The feature maskFilter used below to apply the blur effect only works
+                    with hardware acceleration disabled.
+                 */
+                frameworkPaint.maskFilter =
+                    (BlurMaskFilter(blurRadius.toPx(), BlurMaskFilter.Blur.NORMAL))
+            }
+
+            frameworkPaint.color = color.toArgb()
+            it.drawRoundRect(
+                left = leftPixel,
+                top = topPixel,
+                right = rightPixel,
+                bottom = bottomPixel,
+                radiusX = borderRadius.toPx(),
+                radiusY = borderRadius.toPx(),
+                paint
+            )
+        }
+    }
+)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.navigation.NavController
 import co.nimblehq.compose.crypto.R
@@ -22,6 +23,7 @@ import co.nimblehq.compose.crypto.lib.IsLoading
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenParams
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenPreviewParameterProvider
 import co.nimblehq.compose.crypto.ui.screens.navigation.CryptoScreen
+import co.nimblehq.compose.crypto.ui.theme.Color
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp24
@@ -31,6 +33,7 @@ import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.userReadableMessage
+import co.nimblehq.compose.crypto.extension.boxShadow
 
 @Composable
 fun HomeScreen(
@@ -97,7 +100,15 @@ private fun HomeScreenContent(
 
                 item {
                     PortfolioCard(
-                        modifier = Modifier.padding(start = Dp16, top = Dp40, end = Dp16)
+                        modifier = Modifier
+                            .padding(start = Dp16, top = Dp40, end = Dp16)
+                            .boxShadow(
+                                borderRadius = 3.dp,
+                                color= Color.TiffanyBlue,
+                                blurRadius = 19.dp,
+                                offsetY = 212.dp,
+                                spread = -2.1f
+                            )
                     )
                 }
 


### PR DESCRIPTION
Resolves #22 
Resolves #52

I added code for **Box-Shadow** in `PortfolioCard` Composable using **Kotlin Extension Function**.

And I am Sharing Preview

**Before without Shadow** 
<a href="https://imgur.com/5sSbwgX"><img src="https://i.imgur.com/5sSbwgX.jpg" alt="before PortfolioCard" height="300px" width="150px"/></a>

**After adding Shadow**

<a href="https://imgur.com/Oc3t6ZH"><img src="https://i.imgur.com/Oc3t6ZH.jpg" alt="after PortfolioCard" height="300px" width="150px" /></a>

