### PR TITLE
[#22] [UI] As a user, I can see the shadow effect of the Profit card

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp0
 
 /**
  * Original solution: https://github.com/wasim15185/jetpack-compose-crypto/blob/develop/app/src/main/java/co/nimblehq/compose/crypto/extension/BoxShadow.kt
@@ -22,10 +23,10 @@ import androidx.compose.ui.unit.dp
  */
 fun Modifier.boxShadow(
     color: Color = Color.Black,
-    borderRadius: Dp = 0.dp,
-    blurRadius: Dp = 0.dp,
-    offsetY: Dp = 0.dp,
-    offsetX: Dp = 0.dp,
+    borderRadius: Dp = Dp0,
+    blurRadius: Dp = Dp0,
+    offsetY: Dp = Dp0,
+    offsetX: Dp = Dp0,
     spread: Float = 0f,
     modifier: Modifier = Modifier,
 ) = this.then(
@@ -39,7 +40,7 @@ fun Modifier.boxShadow(
             val rightPixel = (this.size.width + spreadPixel)
             val bottomPixel = (this.size.height + spreadPixel)
 
-            if (blurRadius != 0.dp) {
+            if (blurRadius != Dp0) {
                 /* The feature maskFilter used below to apply the blur effect only works
                     with hardware acceleration disabled.
                  */

--- a/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp0
 
 /**
@@ -27,14 +26,14 @@ fun Modifier.boxShadow(
     blurRadius: Dp = Dp0,
     offsetY: Dp = Dp0,
     offsetX: Dp = Dp0,
-    spread: Float = 0f,
+    spread: Dp = Dp0,
     modifier: Modifier = Modifier,
 ) = this.then(
     modifier.drawBehind {
         this.drawIntoCanvas {
             val paint = Paint()
             val frameworkPaint = paint.asFrameworkPaint()
-            val spreadPixel = spread.dp.toPx()
+            val spreadPixel = spread.toPx()
             val leftPixel = (0f - spreadPixel) + offsetX.toPx()
             val topPixel = (0f - spreadPixel) + offsetY.toPx()
             val rightPixel = (this.size.width + spreadPixel)

--- a/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/extension/ModifierExt.kt
@@ -1,0 +1,62 @@
+package co.nimblehq.compose.crypto.extension
+
+import android.graphics.BlurMaskFilter
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Original solution: https://github.com/wasim15185/jetpack-compose-crypto/blob/develop/app/src/main/java/co/nimblehq/compose/crypto/extension/BoxShadow.kt
+ * Draw a shadow affect under component
+ *
+ * borderRadius: Border radius of shadow
+ * blurRadius: Blur the shadow
+ * offsetY: Position of shadow according to Y axis
+ * offsetX: Position of shadow according to X axis
+ * spread: Squeeze or release the shadow of CardView
+ */
+fun Modifier.boxShadow(
+    color: Color = Color.Black,
+    borderRadius: Dp = 0.dp,
+    blurRadius: Dp = 0.dp,
+    offsetY: Dp = 0.dp,
+    offsetX: Dp = 0.dp,
+    spread: Float = 0f,
+    modifier: Modifier = Modifier,
+) = this.then(
+    modifier.drawBehind {
+        this.drawIntoCanvas {
+            val paint = Paint()
+            val frameworkPaint = paint.asFrameworkPaint()
+            val spreadPixel = spread.dp.toPx()
+            val leftPixel = (0f - spreadPixel) + offsetX.toPx()
+            val topPixel = (0f - spreadPixel) + offsetY.toPx()
+            val rightPixel = (this.size.width + spreadPixel)
+            val bottomPixel = (this.size.height + spreadPixel)
+
+            if (blurRadius != 0.dp) {
+                /* The feature maskFilter used below to apply the blur effect only works
+                    with hardware acceleration disabled.
+                 */
+                frameworkPaint.maskFilter =
+                    (BlurMaskFilter(blurRadius.toPx(), BlurMaskFilter.Blur.NORMAL))
+            }
+
+            frameworkPaint.color = color.toArgb()
+            it.drawRoundRect(
+                left = leftPixel,
+                top = topPixel,
+                right = rightPixel,
+                bottom = bottomPixel,
+                radiusX = borderRadius.toPx(),
+                radiusY = borderRadius.toPx(),
+                paint
+            )
+        }
+    }
+)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -5,9 +5,17 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.*
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -18,15 +26,20 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import co.nimblehq.compose.crypto.R
+import co.nimblehq.compose.crypto.extension.boxShadow
 import co.nimblehq.compose.crypto.lib.IsLoading
 import co.nimblehq.compose.crypto.ui.navigation.AppDestination
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenParams
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenPreviewParameterProvider
+import co.nimblehq.compose.crypto.ui.theme.Color
 import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp24
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp52
+import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBlurRadius
+import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBorderRadius
+import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowOffsetY
 import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
@@ -94,7 +107,15 @@ private fun HomeScreenContent(
 
                 item {
                     PortfolioCard(
-                        modifier = Modifier.padding(start = Dp16, top = Dp40, end = Dp16)
+                        modifier = Modifier
+                            .padding(start = Dp16, top = Dp40, end = Dp16)
+                            .boxShadow(
+                                color = Color.TiffanyBlue,
+                                borderRadius = shadowBorderRadius,
+                                blurRadius = shadowBlurRadius,
+                                offsetY = shadowOffsetY,
+                                spread = -6f
+                            )
                     )
                 }
 

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -40,6 +40,7 @@ import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp52
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBlurRadius
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBorderRadius
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowOffsetY
+import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowSpread
 import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
@@ -114,7 +115,7 @@ private fun HomeScreenContent(
                                 borderRadius = shadowBorderRadius,
                                 blurRadius = shadowBlurRadius,
                                 offsetY = shadowOffsetY,
-                                spread = -6f
+                                spread = shadowSpread
                             )
                     )
                 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
@@ -25,4 +25,5 @@ object Dimension {
     val shadowBorderRadius = 12.dp
     val shadowBlurRadius = 24.dp
     val shadowOffsetY = 212.dp
+    val shadowSpread = (-6).dp
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Dimension.kt
@@ -20,4 +20,9 @@ object Dimension {
     val Dp45 = 45.dp
     val Dp52 = 52.dp
     val Dp60 = 60.dp
+
+    // Card shadow
+    val shadowBorderRadius = 12.dp
+    val shadowBlurRadius = 24.dp
+    val shadowOffsetY = 212.dp
 }


### PR DESCRIPTION
Closes https://github.com/nimblehq/jetpack-compose-crypto/issues/22

## What happened 👀

Add the shadow to below portfolio card

## Insight 📝

- Original solution from our external contributor: https://github.com/wasim15185/jetpack-compose-crypto/blob/develop/app/src/main/java/co/nimblehq/compose/crypto/extension/BoxShadow.kt
- Correct the formatting style and extract dimensions for shadow

## Proof Of Work 📹

<img src="https://user-images.githubusercontent.com/6950766/195815550-053970a9-bb67-420b-9ac1-f77e0eaf9a36.png" width=300 />
