### PR TITLE
[#50] [Integrate] As a user, I can scroll down to refresh the data on Home screen

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -62,8 +62,8 @@ fun HomeScreen(
     LaunchedEffect(viewModel) {
         viewModel.navigator.collect { destination -> navigator(destination) }
     }
-    LaunchedEffect(viewModel.isRefreshing) {
-        viewModel.isRefreshing.collect { isRefreshing ->
+    LaunchedEffect(viewModel.showLoading) {
+        viewModel.showLoading.collect { isRefreshing ->
             rememberRefreshing = isRefreshing
         }
     }
@@ -81,7 +81,7 @@ fun HomeScreen(
         trendingCoins = trendingCoins,
         onMyCoinsItemClick = viewModel.input::onMyCoinsItemClick,
         onTrendingItemClick = viewModel.input::onTrendingCoinsItemClick
-    ) { viewModel.refresh() }
+    ) { viewModel.loadData(isRefreshing = true) }
 }
 
 @OptIn(ExperimentalMaterialApi::class)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -46,7 +46,6 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.userReadableMessage
 
-@ExperimentalMaterialApi
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
@@ -85,7 +84,7 @@ fun HomeScreen(
     ) { viewModel.refresh() }
 }
 
-@ExperimentalMaterialApi
+@OptIn(ExperimentalMaterialApi::class)
 @Suppress("LongParameterList")
 @Composable
 private fun HomeScreenContent(
@@ -276,7 +275,6 @@ private fun MyCoins(
 }
 
 @SuppressLint("UnrememberedMutableState")
-@ExperimentalMaterialApi
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_NO)
 fun HomeScreenPreview(
@@ -298,7 +296,6 @@ fun HomeScreenPreview(
 }
 
 @SuppressLint("UnrememberedMutableState")
-@ExperimentalMaterialApi
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_YES)
 fun HomeScreenPreviewDark(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package co.nimblehq.compose.crypto.ui.screens.home
 
-import android.annotation.SuppressLint
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.widget.Toast
@@ -81,7 +80,7 @@ fun HomeScreen(
         trendingCoins = trendingCoins,
         onMyCoinsItemClick = viewModel.input::onMyCoinsItemClick,
         onTrendingItemClick = viewModel.input::onTrendingCoinsItemClick
-    ) { viewModel.loadData(isRefreshing = true) }
+    ) { viewModel.input.loadData(isRefreshing = true) }
 }
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -95,11 +94,11 @@ private fun HomeScreenContent(
     trendingCoins: List<CoinItemUiModel>,
     onMyCoinsItemClick: (CoinItemUiModel) -> Unit,
     onTrendingItemClick: (CoinItemUiModel) -> Unit,
-    onRefreshing: () -> Unit
+    onRefresh: () -> Unit
 ) {
     val refreshingState = rememberPullRefreshState(
         refreshing = isRefreshing,
-        onRefresh = onRefreshing,
+        onRefresh = onRefresh,
         refreshThreshold = PullRefreshDefaults.RefreshThreshold,
         refreshingOffset = PullRefreshDefaults.RefreshThreshold
     )
@@ -273,7 +272,6 @@ private fun MyCoins(
     }
 }
 
-@SuppressLint("UnrememberedMutableState")
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_NO)
 fun HomeScreenPreview(
@@ -294,7 +292,6 @@ fun HomeScreenPreview(
     }
 }
 
-@SuppressLint("UnrememberedMutableState")
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_YES)
 fun HomeScreenPreviewDark(

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -110,7 +110,6 @@ private fun HomeScreenContent(
                 modifier = Modifier
                     .fillMaxSize()
                     .systemBarsPadding()
-                    .pullRefresh(refreshingState)
             ) {
                 LazyColumn {
                     item {

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.compose.crypto.ui.screens.home
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.widget.Toast
@@ -8,14 +9,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.material.*
+import androidx.compose.material.pullrefresh.PullRefreshDefaults
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -42,16 +41,19 @@ import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBorderRadius
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowOffsetY
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowSpread
 import co.nimblehq.compose.crypto.ui.theme.Style
+import co.nimblehq.compose.crypto.ui.theme.Style.pullRefreshBackgroundColor
 import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.userReadableMessage
 
+@ExperimentalMaterialApi
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
     navigator: (destination: AppDestination) -> Unit
 ) {
     val context = LocalContext.current
+    var rememberRefreshing by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         viewModel.output.error.collect { error ->
             val message = error.userReadableMessage(context)
@@ -60,6 +62,11 @@ fun HomeScreen(
     }
     LaunchedEffect(viewModel) {
         viewModel.navigator.collect { destination -> navigator(destination) }
+    }
+    LaunchedEffect(viewModel.isRefreshing) {
+        viewModel.isRefreshing.collect { isRefreshing ->
+            rememberRefreshing = isRefreshing
+        }
     }
 
     val showMyCoinsLoading: IsLoading by viewModel.showMyCoinsLoading.collectAsState()
@@ -70,103 +77,131 @@ fun HomeScreen(
     HomeScreenContent(
         showMyCoinsLoading = showMyCoinsLoading,
         showTrendingCoinsLoading = showTrendingCoinsLoading,
+        isRefreshing = rememberRefreshing,
         myCoins = myCoins,
         trendingCoins = trendingCoins,
         onMyCoinsItemClick = viewModel.input::onMyCoinsItemClick,
         onTrendingItemClick = viewModel.input::onTrendingCoinsItemClick
-    )
+    ) { viewModel.refresh() }
 }
 
+@ExperimentalMaterialApi
 @Suppress("LongParameterList")
 @Composable
 private fun HomeScreenContent(
     showMyCoinsLoading: IsLoading,
     showTrendingCoinsLoading: IsLoading,
+    isRefreshing: IsLoading,
     myCoins: List<CoinItemUiModel>,
     trendingCoins: List<CoinItemUiModel>,
     onMyCoinsItemClick: (CoinItemUiModel) -> Unit,
-    onTrendingItemClick: (CoinItemUiModel) -> Unit
+    onTrendingItemClick: (CoinItemUiModel) -> Unit,
+    onRefreshing: () -> Unit
 ) {
+    val refreshingState = rememberPullRefreshState(
+        refreshing = isRefreshing,
+        onRefresh = onRefreshing,
+        refreshThreshold = PullRefreshDefaults.RefreshThreshold,
+        refreshingOffset = PullRefreshDefaults.RefreshThreshold
+    )
+
     Surface {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .systemBarsPadding()
-        ) {
-            LazyColumn {
-                item {
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = Dp16),
-                        text = stringResource(id = R.string.home_title),
-                        textAlign = TextAlign.Center,
-                        style = Style.semiBold24(),
-                        color = MaterialTheme.colors.textColor
-                    )
-                }
-
-                item {
-                    PortfolioCard(
-                        modifier = Modifier
-                            .padding(start = Dp16, top = Dp40, end = Dp16)
-                            .boxShadow(
-                                color = Color.TiffanyBlue,
-                                borderRadius = shadowBorderRadius,
-                                blurRadius = shadowBlurRadius,
-                                offsetY = shadowOffsetY,
-                                spread = shadowSpread
-                            )
-                    )
-                }
-
-                item {
-                    MyCoins(
-                        showMyCoinsLoading = showMyCoinsLoading,
-                        coins = myCoins,
-                        onMyCoinsItemClick = onMyCoinsItemClick
-                    )
-                }
-
-                item {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = Dp16, top = Dp24, end = Dp16, bottom = Dp16)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.home_trending_title),
-                            style = Style.medium16(),
-                            color = MaterialTheme.colors.textColor
-                        )
-
-                        SeeAll(
-                            modifier = Modifier
-                                .align(alignment = Alignment.CenterEnd)
-                                .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
-                        )
-                    }
-                }
-
-                if (showTrendingCoinsLoading) {
+        Box(modifier = Modifier.pullRefresh(refreshingState)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .systemBarsPadding()
+                    .pullRefresh(refreshingState)
+            ) {
+                LazyColumn {
                     item {
-                        CircularProgressIndicator(
+                        Text(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .wrapContentWidth(align = Alignment.CenterHorizontally),
+                                .padding(top = Dp16),
+                            text = stringResource(id = R.string.home_title),
+                            textAlign = TextAlign.Center,
+                            style = Style.semiBold24(),
+                            color = MaterialTheme.colors.textColor
                         )
                     }
-                } else {
-                    items(trendingCoins) { coin ->
-                        Box(modifier = Modifier.padding(start = Dp16, end = Dp16, bottom = Dp16)) {
-                            TrendingItem(
-                                coinItem = coin,
-                                onItemClick = { onTrendingItemClick.invoke(coin) }
+
+                    item {
+                        PortfolioCard(
+                            modifier = Modifier
+                                .padding(start = Dp16, top = Dp40, end = Dp16)
+                                .boxShadow(
+                                    color = Color.TiffanyBlue,
+                                    borderRadius = shadowBorderRadius,
+                                    blurRadius = shadowBlurRadius,
+                                    offsetY = shadowOffsetY,
+                                    spread = shadowSpread
+                                )
+                        )
+                    }
+
+                    item {
+                        MyCoins(
+                            showMyCoinsLoading = showMyCoinsLoading,
+                            coins = myCoins,
+                            onMyCoinsItemClick = onMyCoinsItemClick
+                        )
+                    }
+
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = Dp16, top = Dp24, end = Dp16, bottom = Dp16)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.home_trending_title),
+                                style = Style.medium16(),
+                                color = MaterialTheme.colors.textColor
                             )
+
+                            SeeAll(
+                                modifier = Modifier
+                                    .align(alignment = Alignment.CenterEnd)
+                                    .clickable(onClick = { /* TODO: Update on Integrate ticket */ })
+                            )
+                        }
+                    }
+
+                    if (showTrendingCoinsLoading) {
+                        item {
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .wrapContentWidth(align = Alignment.CenterHorizontally),
+                            )
+                        }
+                    } else {
+                        items(trendingCoins) { coin ->
+                            Box(
+                                modifier = Modifier.padding(
+                                    start = Dp16,
+                                    end = Dp16,
+                                    bottom = Dp16
+                                )
+                            ) {
+                                TrendingItem(
+                                    coinItem = coin,
+                                    onItemClick = { onTrendingItemClick.invoke(coin) }
+                                )
+                            }
                         }
                     }
                 }
             }
+
+            PullRefreshIndicator(
+                refreshing = isRefreshing,
+                state = refreshingState,
+                modifier = Modifier.align(alignment = Alignment.TopCenter),
+                backgroundColor = MaterialTheme.colors.pullRefreshBackgroundColor,
+                contentColor = Color.CaribbeanGreen
+            )
         }
     }
 }
@@ -240,6 +275,8 @@ private fun MyCoins(
     }
 }
 
+@SuppressLint("UnrememberedMutableState")
+@ExperimentalMaterialApi
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_NO)
 fun HomeScreenPreview(
@@ -250,15 +287,18 @@ fun HomeScreenPreview(
             HomeScreenContent(
                 showMyCoinsLoading = isLoading,
                 showTrendingCoinsLoading = isLoading,
+                isRefreshing = isLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins,
                 onTrendingItemClick = {},
                 onMyCoinsItemClick = {}
-            )
+            ) {}
         }
     }
 }
 
+@SuppressLint("UnrememberedMutableState")
+@ExperimentalMaterialApi
 @Composable
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_YES)
 fun HomeScreenPreviewDark(
@@ -269,11 +309,12 @@ fun HomeScreenPreviewDark(
             HomeScreenContent(
                 showMyCoinsLoading = isLoading,
                 showTrendingCoinsLoading = isLoading,
+                isRefreshing = isLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins,
                 onTrendingItemClick = {},
                 onMyCoinsItemClick = {}
-            )
+            ) {}
         }
     }
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
@@ -11,7 +11,6 @@ import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.uimodel.toUiModel
 import co.nimblehq.compose.crypto.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
@@ -111,7 +110,6 @@ class HomeViewModel @Inject constructor(
         _showTrendingCoinsLoading.value = false
     }
 
-    @OptIn(FlowPreview::class)
     fun refresh() = execute {
         _isRefreshing.value = true
 

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
@@ -24,6 +24,8 @@ private const val MY_COINS_INITIAL_PAGE = 1
 
 interface Input : BaseInput {
 
+    fun loadData(isRefreshing: Boolean)
+
     fun onMyCoinsItemClick(coin: CoinItemUiModel)
 
     fun onTrendingCoinsItemClick(coin: CoinItemUiModel)
@@ -63,10 +65,10 @@ class HomeViewModel @Inject constructor(
         get() = _trendingCoins
 
     init {
-        loadData()
+        loadData(isRefreshing = false)
     }
 
-    fun loadData(isRefreshing: Boolean = false) {
+    override fun loadData(isRefreshing: Boolean) {
         getMyCoins(isRefreshing)
         getTrendingCoins(isRefreshing)
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
@@ -49,6 +49,10 @@ object Style {
         @Composable
         get() = if (isLight) Quartz else White
 
+    val Colors.pullRefreshBackgroundColor: Color
+        @Composable
+        get() = if (isLight) DarkJungleGreen else White
+
     @Composable
     fun medium12() = textStyle.copy(fontWeight = FontWeight.Medium, fontSize = Sp12)
 

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
@@ -51,7 +51,7 @@ object Style {
 
     val Colors.pullRefreshBackgroundColor: Color
         @Composable
-        get() = if (isLight) DarkJungleGreen else White
+        get() = if (isLight) White else DarkJungleGreen
 
     @Composable
     fun medium12() = textStyle.copy(fontWeight = FontWeight.Medium, fontSize = Sp12)

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val BUILD_GRADLE_VERSION = "7.0.4"
 
-    const val ANDROID_COMPILE_SDK_VERSION = 32
+    const val ANDROID_COMPILE_SDK_VERSION = 33
     const val ANDROID_MIN_SDK_VERSION = 23
     const val ANDROID_TARGET_SDK_VERSION = 32
 
@@ -15,7 +15,7 @@ object Versions {
     const val ANDROIDX_LIFECYCLE_VERSION = "2.5.1"
     const val ANDROIDX_NAVIGATION_COMPOSE_VERSION = "2.5.1"
 
-    const val COMPOSE_VERSION = "1.2.0-rc01"
+    const val COMPOSE_VERSION = "1.3.0-rc01"
     const val COMPOSE_CONSTRAINT_LAYOUT_VERSION = "1.0.1"
     const val COMPOSE_CHART_VERSION = "0.1.2"
     const val COIL_VERSION = "2.0.0" // API 31
@@ -30,8 +30,8 @@ object Versions {
     const val JAVAX_INJECT_VERSION = "1"
     const val JACOCO_VERSION = "0.8.7"
 
-    const val KOTLIN_REFLECT_VERSION = "1.6.21"
-    const val KOTLIN_VERSION = "1.6.21"
+    const val KOTLIN_REFLECT_VERSION = "1.7.10"
+    const val KOTLIN_VERSION = "1.7.10"
     const val KOTLINX_COROUTINES_VERSION = "1.6.4"
 
     const val MOSHI_VERSION = "1.12.0"


### PR DESCRIPTION
Closes https://github.com/nimblehq/jetpack-compose-crypto/issues/50

## What happened 👀

- To use Pull to refresh, we have to update to the latest compose version `1.3.0-rc01`
- Handle on refreshing to re-fetch trending coin and my coin list.

## Insight 📝

There is an old approach with `SwipeRefresh` from `accompanist` library (https://google.github.io/accompanist/swiperefresh/), I'd go with an alternative approach from the latest release by using `PullRefreshIndicator`

## Proof Of Work 📹

https://user-images.githubusercontent.com/6950766/196234331-6872147f-53ec-4257-9705-bf853996c08b.mp4
