### PR TITLE
[#60] Fix: The Coin prices period text color show incorrect on Light mode

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/components/chartintervals/ChartIntervalsButton.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/components/chartintervals/ChartIntervalsButton.kt
@@ -9,9 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import co.nimblehq.compose.crypto.ui.theme.Color
+import co.nimblehq.compose.crypto.ui.theme.Color.CaribbeanGreen
+import co.nimblehq.compose.crypto.ui.theme.Color.OsloGray
+import co.nimblehq.compose.crypto.ui.theme.Color.Transparent
+import co.nimblehq.compose.crypto.ui.theme.Color.White
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp14
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp4
@@ -33,15 +37,15 @@ fun ChartIntervalsButtonGroup(
 
         TimeIntervals.values().forEachIndexed { index, interval ->
             val backgroundColor = if (selectedColor.value == index) {
-                Color.CaribbeanGreen
+                CaribbeanGreen
             } else {
-                Color.Transparent
+                Transparent
             }
 
             val textColor = if (selectedColor.value == index) {
-                Color.White
+                White
             } else {
-                Color.OsloGray
+                OsloGray
             }
 
             ChartIntervalsButton(
@@ -67,7 +71,7 @@ fun ChartIntervalsButtonGroup(
 @Composable
 fun ChartIntervalsButton(
     modifier: Modifier,
-    textColor: androidx.compose.ui.graphics.Color,
+    textColor: Color,
     interval: TimeIntervals,
     onClick: () -> Unit
 ) {

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/components/chartintervals/ChartIntervalsButton.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/components/chartintervals/ChartIntervalsButton.kt
@@ -38,6 +38,12 @@ fun ChartIntervalsButtonGroup(
                 Color.Transparent
             }
 
+            val textColor = if (selectedColor.value == index) {
+                Color.White
+            } else {
+                Color.OsloGray
+            }
+
             ChartIntervalsButton(
                 modifier = Modifier
                     .requiredWidth(Dp45)
@@ -45,6 +51,7 @@ fun ChartIntervalsButtonGroup(
                         color = backgroundColor,
                         shape = RoundedCornerShape(Dp12)
                     ),
+                textColor = textColor,
                 interval = interval,
                 onClick = {
                     if (selectedColor.value != index) {
@@ -60,6 +67,7 @@ fun ChartIntervalsButtonGroup(
 @Composable
 fun ChartIntervalsButton(
     modifier: Modifier,
+    textColor: androidx.compose.ui.graphics.Color,
     interval: TimeIntervals,
     onClick: () -> Unit
 ) {
@@ -69,7 +77,7 @@ fun ChartIntervalsButton(
             .padding(vertical = Dp4, horizontal = Dp8),
         textAlign = TextAlign.Center,
         text = interval.text,
-        color = Color.White,
+        color = textColor,
         style = Style.medium14()
     )
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Color.kt
@@ -19,4 +19,5 @@ object Color {
     val SonicSilver = Color(0xFF70747C)
     val CaribbeanGreen = Color(0xFF00BDB0)
     val CaribbeanGreenAlpha30 = CaribbeanGreen.copy(alpha = 0.3f)
+    val OsloGray = Color(0xFF8D9096)
 }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
@@ -1,8 +1,8 @@
 package co.nimblehq.compose.crypto.ui.theme
 
 import androidx.compose.material.Colors
-import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -10,7 +10,6 @@ import androidx.compose.ui.text.font.FontWeight
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
 import co.nimblehq.compose.crypto.ui.theme.Color.LightSilver
-import co.nimblehq.compose.crypto.ui.theme.Color.OsloGray
 import co.nimblehq.compose.crypto.ui.theme.Color.Quartz
 import co.nimblehq.compose.crypto.ui.theme.Color.QuartzAlpha20
 import co.nimblehq.compose.crypto.ui.theme.Color.SonicSilver
@@ -49,10 +48,6 @@ object Style {
     val Colors.coinInfoAppBarIconColor: Color
         @Composable
         get() = if (isLight) Quartz else White
-
-    val Colors.coinPriceIntervalTextColor: Color
-        @Composable
-        get() = if (isLight) OsloGray else White
 
     @Composable
     fun medium12() = textStyle.copy(fontWeight = FontWeight.Medium, fontSize = Sp12)

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/theme/Style.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.font.FontWeight
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.ui.theme.Color.DarkJungleGreen
 import co.nimblehq.compose.crypto.ui.theme.Color.LightSilver
+import co.nimblehq.compose.crypto.ui.theme.Color.OsloGray
 import co.nimblehq.compose.crypto.ui.theme.Color.Quartz
 import co.nimblehq.compose.crypto.ui.theme.Color.QuartzAlpha20
 import co.nimblehq.compose.crypto.ui.theme.Color.SonicSilver
@@ -48,6 +49,10 @@ object Style {
     val Colors.coinInfoAppBarIconColor: Color
         @Composable
         get() = if (isLight) Quartz else White
+
+    val Colors.coinPriceIntervalTextColor: Color
+        @Composable
+        get() = if (isLight) OsloGray else White
 
     @Composable
     fun medium12() = textStyle.copy(fontWeight = FontWeight.Medium, fontSize = Sp12)


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-crypto/issues/60

## What happened 👀

Update the text color in Light Mode for the Coin price interval button

## Insight 📝

Add the text color to `Color.kt` to supported Light/Dark mode

## Proof Of Work 📹

|Dark|Light|
|-|-|
|![image](https://user-images.githubusercontent.com/6950766/198819000-d7e8a8a3-a169-4c08-86a0-ad3ecd796132.png)|![image](https://user-images.githubusercontent.com/6950766/198819059-a3f5616f-50a4-4774-9a3f-d95bcc3fbc57.png)|
