### PR TITLE
[#32] [Integrate] As a user, I can see more coins on the Trending list when scrolling down

### DIFF
--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/base/LoadingState.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/base/LoadingState.kt
@@ -1,0 +1,7 @@
+package co.nimblehq.compose.crypto.ui.base
+
+sealed class LoadingState {
+    object Idle : LoadingState()
+    object Loading : LoadingState()
+    object LoadingMore : LoadingState()
+}

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/preview/HomeScreenPreviewParameterProvider.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/preview/HomeScreenPreviewParameterProvider.kt
@@ -2,6 +2,7 @@ package co.nimblehq.compose.crypto.ui.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import co.nimblehq.compose.crypto.lib.IsLoading
+import co.nimblehq.compose.crypto.ui.base.LoadingState
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 
 class HomeScreenPreviewParameterProvider : PreviewParameterProvider<HomeScreenParams> {
@@ -9,12 +10,14 @@ class HomeScreenPreviewParameterProvider : PreviewParameterProvider<HomeScreenPa
         HomeScreenParams(
             listOf(coinItemPreview),
             listOf(coinItemPreview),
-            false
+            false,
+            LoadingState.Idle
         ),
         HomeScreenParams(
             listOf(coinItemPreview),
             listOf(coinItemPreview),
-            true
+            true,
+            LoadingState.Loading
         ),
     )
 }
@@ -22,5 +25,6 @@ class HomeScreenPreviewParameterProvider : PreviewParameterProvider<HomeScreenPa
 data class HomeScreenParams(
     val myCoins: List<CoinItemUiModel>,
     val trendingCoins: List<CoinItemUiModel>,
-    val isLoading: IsLoading
+    val isMyCoinsLoading: IsLoading,
+    val isTrendingCoinsLoading: LoadingState
 )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -59,7 +59,7 @@ fun HomeScreen(
         }
     }
     LaunchedEffect(viewModel) {
-        viewModel.navigator.collect { destination -> navigator(destination) }
+        viewModel.output.navigator.collect { destination -> navigator(destination) }
     }
     LaunchedEffect(viewModel.showLoading) {
         viewModel.showLoading.collect { isRefreshing ->
@@ -69,8 +69,8 @@ fun HomeScreen(
 
     val showMyCoinsLoading: IsLoading by viewModel.output.showMyCoinsLoading.collectAsState()
     val showTrendingCoinsLoading: LoadingState by viewModel.output.showTrendingCoinsLoading.collectAsState()
-    val myCoins: List<CoinItemUiModel> by viewModel.myCoins.collectAsState()
-    val trendingCoins: List<CoinItemUiModel> by viewModel.trendingCoins.collectAsState()
+    val myCoins: List<CoinItemUiModel> by viewModel.output.myCoins.collectAsState()
+    val trendingCoins: List<CoinItemUiModel> by viewModel.output.trendingCoins.collectAsState()
 
     HomeScreenContent(
         showMyCoinsLoading = showMyCoinsLoading,
@@ -94,8 +94,8 @@ private fun HomeScreenContent(
     isRefreshing: IsLoading,
     myCoins: List<CoinItemUiModel>,
     trendingCoins: List<CoinItemUiModel>,
-    onMyCoinsItemClick: (CoinItemUiModel) -> Unit,
-    onTrendingItemClick: (CoinItemUiModel) -> Unit,
+    onMyCoinsItemClick: ((CoinItemUiModel) -> Unit)? = null,
+    onTrendingItemClick: ((CoinItemUiModel) -> Unit)? = null,
     onRefresh: () -> Unit = {},
     onTrendingCoinsLoadMore: () -> Unit = {}
 ) {
@@ -195,7 +195,7 @@ private fun HomeScreenContent(
                             ) {
                                 TrendingItem(
                                     coinItem = coin,
-                                    onItemClick = { onTrendingItemClick.invoke(coin) }
+                                    onItemClick = { onTrendingItemClick?.invoke(coin) }
                                 )
                             }
                         }
@@ -229,7 +229,7 @@ private fun HomeScreenContent(
 private fun MyCoins(
     showMyCoinsLoading: IsLoading,
     coins: List<CoinItemUiModel>,
-    onMyCoinsItemClick: (CoinItemUiModel) -> Unit
+    onMyCoinsItemClick: ((CoinItemUiModel) -> Unit)? = null
 ) {
     ConstraintLayout(
         modifier = Modifier
@@ -286,7 +286,7 @@ private fun MyCoins(
                 items(coins) { coin ->
                     CoinItem(
                         coinItem = coin,
-                        onItemClick = { onMyCoinsItemClick.invoke(coin) }
+                        onItemClick = { onMyCoinsItemClick?.invoke(coin) }
                     )
                 }
             }
@@ -306,9 +306,7 @@ fun HomeScreenPreview(
                 showTrendingCoinsLoading = isTrendingCoinsLoading,
                 isRefreshing = isLoading,
                 myCoins = myCoins,
-                trendingCoins = trendingCoins,
-                onTrendingItemClick = {},
-                onMyCoinsItemClick = {}
+                trendingCoins = trendingCoins
             )
         }
     }
@@ -326,9 +324,7 @@ fun HomeScreenPreviewDark(
                 showTrendingCoinsLoading = isTrendingCoinsLoading,
                 isRefreshing = isLoading,
                 myCoins = myCoins,
-                trendingCoins = trendingCoins,
-                onTrendingItemClick = {},
-                onMyCoinsItemClick = {}
+                trendingCoins = trendingCoins
             )
         }
     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -204,7 +204,8 @@ private fun HomeScreenContent(
                             CircularProgressIndicator(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .wrapContentWidth(align = Alignment.CenterHorizontally),
+                                    .wrapContentWidth(align = Alignment.CenterHorizontally)
+                                    .padding(bottom = Dp16)
                             )
                         }
                     }

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -7,10 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
 import androidx.compose.material.*
-import androidx.compose.material.pullrefresh.PullRefreshDefaults
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material.pullrefresh.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,8 +25,7 @@ import co.nimblehq.compose.crypto.ui.base.LoadingState
 import co.nimblehq.compose.crypto.ui.navigation.AppDestination
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenParams
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenPreviewParameterProvider
-import co.nimblehq.compose.crypto.ui.theme.Color
-import co.nimblehq.compose.crypto.ui.theme.ComposeTheme
+import co.nimblehq.compose.crypto.ui.theme.*
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp24
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
@@ -38,12 +34,13 @@ import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBlurRadius
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowBorderRadius
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowOffsetY
 import co.nimblehq.compose.crypto.ui.theme.Dimension.shadowSpread
-import co.nimblehq.compose.crypto.ui.theme.Style
 import co.nimblehq.compose.crypto.ui.theme.Style.pullRefreshBackgroundColor
 import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.userReadableMessage
 import timber.log.Timber
+
+private const val LIST_ITEM_LOAD_MORE_THRESHOLD = 0
 
 @Composable
 fun HomeScreen(
@@ -94,8 +91,8 @@ private fun HomeScreenContent(
     isRefreshing: IsLoading,
     myCoins: List<CoinItemUiModel>,
     trendingCoins: List<CoinItemUiModel>,
-    onMyCoinsItemClick: ((CoinItemUiModel) -> Unit)? = null,
-    onTrendingItemClick: ((CoinItemUiModel) -> Unit)? = null,
+    onMyCoinsItemClick: (CoinItemUiModel) -> Unit = {},
+    onTrendingItemClick: (CoinItemUiModel) -> Unit = {},
     onRefresh: () -> Unit = {},
     onTrendingCoinsLoadMore: () -> Unit = {}
 ) {
@@ -171,7 +168,7 @@ private fun HomeScreenContent(
                     }
 
                     // Full section loading
-                if (showTrendingCoinsLoading == LoadingState.Loading) {
+                    if (showTrendingCoinsLoading == LoadingState.Loading) {
                         item {
                             CircularProgressIndicator(
                                 modifier = Modifier
@@ -181,7 +178,7 @@ private fun HomeScreenContent(
                         }
                     } else {
                         itemsIndexed(trendingCoins) { index, coin ->
-                            if (index >= trendingCoinsLastIndex) {
+                            if (index + LIST_ITEM_LOAD_MORE_THRESHOLD >= trendingCoinsLastIndex) {
                                 SideEffect {
                                     Timber.d("onTrendingCoinsLoadMore at index: $index, lastIndex: $trendingCoinsLastIndex")
                                     onTrendingCoinsLoadMore.invoke()
@@ -195,7 +192,7 @@ private fun HomeScreenContent(
                             ) {
                                 TrendingItem(
                                     coinItem = coin,
-                                    onItemClick = { onTrendingItemClick?.invoke(coin) }
+                                    onItemClick = { onTrendingItemClick.invoke(coin) }
                                 )
                             }
                         }
@@ -229,7 +226,7 @@ private fun HomeScreenContent(
 private fun MyCoins(
     showMyCoinsLoading: IsLoading,
     coins: List<CoinItemUiModel>,
-    onMyCoinsItemClick: ((CoinItemUiModel) -> Unit)? = null
+    onMyCoinsItemClick: (CoinItemUiModel) -> Unit
 ) {
     ConstraintLayout(
         modifier = Modifier
@@ -286,7 +283,7 @@ private fun MyCoins(
                 items(coins) { coin ->
                     CoinItem(
                         coinItem = coin,
-                        onItemClick = { onMyCoinsItemClick?.invoke(coin) }
+                        onItemClick = { onMyCoinsItemClick.invoke(coin) }
                     )
                 }
             }
@@ -304,7 +301,7 @@ fun HomeScreenPreview(
             HomeScreenContent(
                 showMyCoinsLoading = isMyCoinsLoading,
                 showTrendingCoinsLoading = isTrendingCoinsLoading,
-                isRefreshing = isLoading,
+                isRefreshing = isMyCoinsLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins
             )
@@ -322,7 +319,7 @@ fun HomeScreenPreviewDark(
             HomeScreenContent(
                 showMyCoinsLoading = isMyCoinsLoading,
                 showTrendingCoinsLoading = isTrendingCoinsLoading,
-                isRefreshing = isLoading,
+                isRefreshing = isMyCoinsLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins
             )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -24,6 +24,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import co.nimblehq.compose.crypto.R
 import co.nimblehq.compose.crypto.extension.boxShadow
 import co.nimblehq.compose.crypto.lib.IsLoading
+import co.nimblehq.compose.crypto.ui.base.LoadingState
 import co.nimblehq.compose.crypto.ui.navigation.AppDestination
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenParams
 import co.nimblehq.compose.crypto.ui.preview.HomeScreenPreviewParameterProvider
@@ -66,8 +67,8 @@ fun HomeScreen(
         }
     }
 
-    val showMyCoinsLoading: IsLoading by viewModel.showMyCoinsLoading.collectAsState()
-    val showTrendingCoinsLoading: IsLoading by viewModel.showTrendingCoinsLoading.collectAsState()
+    val showMyCoinsLoading: IsLoading by viewModel.output.showMyCoinsLoading.collectAsState()
+    val showTrendingCoinsLoading: LoadingState by viewModel.output.showTrendingCoinsLoading.collectAsState()
     val myCoins: List<CoinItemUiModel> by viewModel.myCoins.collectAsState()
     val trendingCoins: List<CoinItemUiModel> by viewModel.trendingCoins.collectAsState()
 
@@ -89,7 +90,7 @@ fun HomeScreen(
 @Composable
 private fun HomeScreenContent(
     showMyCoinsLoading: IsLoading,
-    showTrendingCoinsLoading: IsLoading,
+    showTrendingCoinsLoading: LoadingState,
     isRefreshing: IsLoading,
     myCoins: List<CoinItemUiModel>,
     trendingCoins: List<CoinItemUiModel>,
@@ -169,7 +170,8 @@ private fun HomeScreenContent(
                         }
                     }
 
-                    if (showTrendingCoinsLoading) {
+                    // Full section loading
+                if (showTrendingCoinsLoading == LoadingState.Loading) {
                         item {
                             CircularProgressIndicator(
                                 modifier = Modifier
@@ -196,6 +198,17 @@ private fun HomeScreenContent(
                                     onItemClick = { onTrendingItemClick.invoke(coin) }
                                 )
                             }
+                        }
+                    }
+
+                    // Load more loading
+                    if (showTrendingCoinsLoading == LoadingState.LoadingMore) {
+                        item {
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .wrapContentWidth(align = Alignment.CenterHorizontally),
+                            )
                         }
                     }
                 }
@@ -289,8 +302,8 @@ fun HomeScreenPreview(
     with(params) {
         ComposeTheme {
             HomeScreenContent(
-                showMyCoinsLoading = isLoading,
-                showTrendingCoinsLoading = isLoading,
+                showMyCoinsLoading = isMyCoinsLoading,
+                showTrendingCoinsLoading = isTrendingCoinsLoading,
                 isRefreshing = isLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins,
@@ -309,8 +322,8 @@ fun HomeScreenPreviewDark(
     with(params) {
         ComposeTheme {
             HomeScreenContent(
-                showMyCoinsLoading = isLoading,
-                showTrendingCoinsLoading = isLoading,
+                showMyCoinsLoading = isMyCoinsLoading,
+                showTrendingCoinsLoading = isTrendingCoinsLoading,
                 isRefreshing = isLoading,
                 myCoins = myCoins,
                 trendingCoins = trendingCoins,

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
@@ -9,9 +9,7 @@ import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import co.nimblehq.compose.crypto.ui.uimodel.toUiModel
 import co.nimblehq.compose.crypto.util.DispatchersProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 const val FIAT_CURRENCY = "usd"
@@ -117,11 +115,12 @@ class HomeViewModel @Inject constructor(
                     _error.emit(e)
                 }
                 .collect { coins ->
-                    val newList = coins.map { it.toUiModel() }
-                    _trendingCoins.emit(_trendingCoins.value + newList)
+                    val newCoinList = coins.map { it.toUiModel() }
+                    _trendingCoins.emit(_trendingCoins.value + newCoinList)
                     page++
                 }
-            if (isRefreshing) hideLoading() else _showTrendingCoinsLoading.value = LoadingState.Idle
+            if (isRefreshing) hideLoading() else
+                _showTrendingCoinsLoading.value = LoadingState.Idle
         }
     }
 

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModel.kt
@@ -66,13 +66,16 @@ class HomeViewModel @Inject constructor(
     override val trendingCoins: StateFlow<List<CoinItemUiModel>>
         get() = _trendingCoins
 
-    private var page = MY_COINS_INITIAL_PAGE
+    private var trendingCoinsPage = MY_COINS_INITIAL_PAGE
 
     init {
         loadData()
     }
 
     override fun loadData(isRefreshing: Boolean) {
+        if (isRefreshing) {
+            trendingCoinsPage = MY_COINS_INITIAL_PAGE
+        }
         getMyCoins(isRefreshing = isRefreshing)
         getTrendingCoins(isRefreshing = isRefreshing)
     }
@@ -108,7 +111,7 @@ class HomeViewModel @Inject constructor(
                     order = MY_COINS_ORDER,
                     priceChangeInHour = MY_COINS_PRICE_CHANGE_IN_HOUR,
                     itemPerPage = MY_COINS_ITEM_PER_PAGE,
-                    page = page
+                    page = trendingCoinsPage
                 )
             )
                 .catch { e ->
@@ -116,8 +119,12 @@ class HomeViewModel @Inject constructor(
                 }
                 .collect { coins ->
                     val newCoinList = coins.map { it.toUiModel() }
-                    _trendingCoins.emit(_trendingCoins.value + newCoinList)
-                    page++
+                    if (isRefreshing) {
+                        _trendingCoins.emit(newCoinList)
+                    } else {
+                        _trendingCoins.emit(_trendingCoins.value + newCoinList)
+                    }
+                    trendingCoinsPage++
                 }
             if (isRefreshing) hideLoading() else
                 _showTrendingCoinsLoading.value = LoadingState.Idle


### PR DESCRIPTION
Resolves https://github.com/nimblehq/jetpack-compose-crypto/issues/32

## What happened 👀

- Implement `load more` feature on the Trending Coin list on the bottom.
- Implement `load more` loading progress at the end of the list.

## Insight 📝

- To build the load more feature, we need to set `rememberLazyListState` to the LazyColumn's state. Then, when rendering list items, we will check to current render index to the `trendingCoins.lastIndex` to trigger the load more action in ViewModel.

- After implementing the load more function, the current loading progress will replace the current Trending list page items. To fix this, we need to show the load more's loading progress at the end of the list instead of replacing the whole list item. The need is to create a new sealed class `LoadingState` with 3 states **Idle** (~ false), **Loading** (~ true) and **LoadingMore** (the new `true` with load more).

## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/200374368-0a6d3456-8dca-4c10-9d4d-b84180f75eb0.mp4

