### PR TITLE
[#69] Create HomeScreen UnitTest

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,12 @@ android {
         xmlReport = true
         xmlOutput = file("build/reports/lint/lint-result.xml")
     }
+
+    testOptions {
+        unitTests { 
+            isIncludeAndroidResources = true
+        }
+    }
 }
 
 kapt {
@@ -158,6 +164,8 @@ dependencies {
     testImplementation("io.mockk:mockk:${Versions.TEST_MOCKK_VERSION}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.TEST_COROUTINES_VERSION}")
     testImplementation("app.cash.turbine:turbine:${Versions.TEST_TURBINE_VERSION}")
+    testImplementation ("androidx.compose.ui:ui-test-junit4:${Versions.COMPOSE_VERSION}")
+    testImplementation ("org.robolectric:robolectric:${Versions.TEST_ROBOLECTRIC_VERSION}")
 
     kaptTest("com.google.dagger:hilt-android-compiler:${Versions.HILT_VERSION}")
     testAnnotationProcessor("com.google.dagger:hilt-android-compiler:${Versions.HILT_VERSION}")

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -38,13 +39,19 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import coil.compose.rememberAsyncImagePainter
 
+const val TestTagCoinItemSymbol = "CoinItemCoinSymbol"
+const val TestTagCoinItemCoinName = "CoinItemCoinName"
+const val TestTagCoinItemPrice = "CoinItemPrice"
+const val TestTagCoinItemPriceChange = "CoinItemPriceChange"
+
 @Composable
 fun CoinItem(
+    modifier: Modifier,
     coinItem: CoinItemUiModel,
     onItemClick: () -> Unit
 ) {
     ConstraintLayout(
-        modifier = Modifier
+        modifier = modifier
             .wrapContentWidth()
             .clip(RoundedCornerShape(Dp12))
             .clickable { onItemClick.invoke() }
@@ -76,7 +83,8 @@ fun CoinItem(
                 .constrainAs(coinSymbol) {
                     top.linkTo(parent.top)
                     start.linkTo(anchor = logo.end, margin = Dp16)
-                },
+                }
+                .testTag(tag = TestTagCoinItemSymbol),
             text = coinItem.symbol.uppercase(),
             color = MaterialTheme.colors.textColor,
             style = Style.semiBold16()
@@ -89,7 +97,8 @@ fun CoinItem(
                     start.linkTo(coinSymbol.start)
                     top.linkTo(coinSymbol.bottom)
                     width = Dimension.preferredWrapContent
-                },
+                }
+                .testTag(tag = TestTagCoinItemCoinName),
             text = coinItem.coinName,
             color = MaterialTheme.colors.coinNameColor,
             style = Style.medium14()
@@ -101,7 +110,8 @@ fun CoinItem(
                     start.linkTo(logo.start)
                     top.linkTo(anchor = coinName.bottom, margin = Dp14)
                     width = Dimension.preferredWrapContent
-                },
+                }
+                .testTag(tag = TestTagCoinItemPrice),
             text = stringResource(
                 R.string.coin_currency,
                 coinItem.currentPrice.toFormattedString()
@@ -119,6 +129,7 @@ fun CoinItem(
                     bottom.linkTo(parent.bottom)
                     width = Dimension.preferredWrapContent
                 }
+                .testTag(tag = TestTagCoinItemPriceChange)
         )
     }
 }
@@ -130,6 +141,7 @@ fun CoinItemPreview(
 ) {
     ComposeTheme {
         CoinItem(
+            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )
@@ -143,6 +155,7 @@ fun CoinItemPreviewDark(
 ) {
     ComposeTheme {
         CoinItem(
+            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/CoinItem.kt
@@ -46,7 +46,7 @@ const val TestTagCoinItemPriceChange = "CoinItemPriceChange"
 
 @Composable
 fun CoinItem(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     coinItem: CoinItemUiModel,
     onItemClick: () -> Unit
 ) {
@@ -141,7 +141,6 @@ fun CoinItemPreview(
 ) {
     ComposeTheme {
         CoinItem(
-            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )
@@ -155,7 +154,6 @@ fun CoinItemPreviewDark(
 ) {
     ComposeTheme {
         CoinItem(
-            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -43,6 +43,7 @@ import timber.log.Timber
 
 private const val LIST_ITEM_LOAD_MORE_THRESHOLD = 0
 
+const val TestTagHomeTitle = "HomeTitle"
 const val TestTagTrendingItem = "TrendingItem"
 const val TestTagCoinItem = "CoinItem"
 const val TestTagCoinsLoader = "CoinsLoader"
@@ -130,7 +131,7 @@ private fun HomeScreenContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = Dp16)
-                                .testTag(tag = stringResource(id = R.string.home_title)),
+                                .testTag(TestTagHomeTitle),
                             text = stringResource(id = R.string.home_title),
                             textAlign = TextAlign.Center,
                             style = Style.semiBold24(),

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,6 +43,10 @@ import timber.log.Timber
 
 private const val LIST_ITEM_LOAD_MORE_THRESHOLD = 0
 
+const val TestTagTrendingItem = "TrendingItem"
+const val TestTagCoinItem = "CoinItem"
+const val TestTagCoinsLoader = "CoinsLoader"
+
 @Composable
 fun HomeScreen(
     viewModel: HomeViewModel = hiltViewModel(),
@@ -49,14 +54,11 @@ fun HomeScreen(
 ) {
     val context = LocalContext.current
     var rememberRefreshing by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        viewModel.output.error.collect { error ->
-            val message = error.userReadableMessage(context)
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-        }
-    }
+
     LaunchedEffect(viewModel) {
-        viewModel.output.navigator.collect { destination -> navigator(destination) }
+        viewModel.output.navigator.collect { destination ->
+            navigator(destination)
+        }
     }
     LaunchedEffect(viewModel.showLoading) {
         viewModel.showLoading.collect { isRefreshing ->
@@ -68,6 +70,16 @@ fun HomeScreen(
     val showTrendingCoinsLoading: LoadingState by viewModel.output.showTrendingCoinsLoading.collectAsState()
     val myCoins: List<CoinItemUiModel> by viewModel.output.myCoins.collectAsState()
     val trendingCoins: List<CoinItemUiModel> by viewModel.output.trendingCoins.collectAsState()
+    val myCoinsError: Throwable? by viewModel.output.myCoinsError.collectAsState()
+    val trendingCoinsError: Throwable? by viewModel.output.trendingCoinsError.collectAsState()
+
+    myCoinsError?.let { error ->
+        Toast.makeText(context, error.userReadableMessage(context), Toast.LENGTH_SHORT).show()
+    }
+
+    trendingCoinsError?.let { error ->
+        Toast.makeText(context, error.userReadableMessage(context), Toast.LENGTH_SHORT).show()
+    }
 
     HomeScreenContent(
         showMyCoinsLoading = showMyCoinsLoading,
@@ -117,7 +129,8 @@ private fun HomeScreenContent(
                         Text(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(top = Dp16),
+                                .padding(top = Dp16)
+                                .testTag(tag = stringResource(id = R.string.home_title)),
                             text = stringResource(id = R.string.home_title),
                             textAlign = TextAlign.Center,
                             style = Style.semiBold24(),
@@ -173,7 +186,8 @@ private fun HomeScreenContent(
                             CircularProgressIndicator(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .wrapContentWidth(align = Alignment.CenterHorizontally),
+                                    .wrapContentWidth(align = Alignment.CenterHorizontally)
+                                    .testTag(tag = TestTagCoinsLoader),
                             )
                         }
                     } else {
@@ -191,6 +205,7 @@ private fun HomeScreenContent(
                                 )
                             ) {
                                 TrendingItem(
+                                    modifier = Modifier.testTag(tag = TestTagTrendingItem),
                                     coinItem = coin,
                                     onItemClick = { onTrendingItemClick.invoke(coin) }
                                 )
@@ -206,6 +221,7 @@ private fun HomeScreenContent(
                                     .fillMaxWidth()
                                     .wrapContentWidth(align = Alignment.CenterHorizontally)
                                     .padding(bottom = Dp16)
+                                    .testTag(tag = TestTagCoinsLoader),
                             )
                         }
                     }
@@ -269,7 +285,8 @@ private fun MyCoins(
                     .constrainAs(myCoins) {
                         top.linkTo(myCoinsTitle.bottom, margin = Dp16)
                         linkTo(start = parent.start, end = parent.end)
-                    },
+                    }
+                    .testTag(tag = TestTagCoinsLoader),
             )
         } else {
             LazyRow(
@@ -283,6 +300,7 @@ private fun MyCoins(
             ) {
                 items(coins) { coin ->
                     CoinItem(
+                        modifier = Modifier.testTag(tag = TestTagCoinItem),
                         coinItem = coin,
                         onItemClick = { onMyCoinsItemClick.invoke(coin) }
                     )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
@@ -21,6 +21,8 @@ import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
 
+const val TestTagTotalCoinsLabel = "CardTotalCoinsLabel"
+const val TestTagTodayCoinProfitLabel = "todayProfitLabel"
 const val TestTagCardTotalCoins = "CardTotalCoins"
 const val TestTagCardTodayProfit = "CardTodayProfit"
 
@@ -52,7 +54,7 @@ fun PortfolioCard(
                 .constrainAs(totalCoinsLabel) {
                     start.linkTo(parent.start)
                 }
-                .testTag(tag = stringResource(R.string.portfolio_card_total_coin_label)),
+                .testTag(TestTagTotalCoinsLabel),
             text = stringResource(R.string.portfolio_card_total_coin_label),
             style = Style.lightSilverMedium16()
         )
@@ -73,7 +75,7 @@ fun PortfolioCard(
                 .constrainAs(todayProfitLabel) {
                     top.linkTo(totalCoins.bottom, margin = Dp40)
                 }
-                .testTag(tag = stringResource(R.string.portfolio_card_today_profit_label)),
+                .testTag(tag = TestTagTodayCoinProfitLabel),
             text = stringResource(R.string.portfolio_card_today_profit_label),
             style = Style.lightSilverMedium16()
         )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/PortfolioCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -19,6 +20,9 @@ import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp12
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp16
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp40
 import co.nimblehq.compose.crypto.ui.theme.Dimension.Dp8
+
+const val TestTagCardTotalCoins = "CardTotalCoins"
+const val TestTagCardTodayProfit = "CardTodayProfit"
 
 @Composable
 fun PortfolioCard(
@@ -47,7 +51,8 @@ fun PortfolioCard(
             modifier = Modifier
                 .constrainAs(totalCoinsLabel) {
                     start.linkTo(parent.start)
-                },
+                }
+                .testTag(tag = stringResource(R.string.portfolio_card_total_coin_label)),
             text = stringResource(R.string.portfolio_card_total_coin_label),
             style = Style.lightSilverMedium16()
         )
@@ -56,7 +61,8 @@ fun PortfolioCard(
             modifier = Modifier
                 .constrainAs(totalCoins) {
                     top.linkTo(totalCoinsLabel.bottom, margin = Dp8)
-                },
+                }
+                .testTag(tag = TestTagCardTotalCoins),
             // TODO: Remove dummy value when work on Integrate.
             text = stringResource(R.string.coin_currency, "7,273,291"),
             style = Style.whiteSemiBold24()
@@ -66,7 +72,8 @@ fun PortfolioCard(
             modifier = Modifier
                 .constrainAs(todayProfitLabel) {
                     top.linkTo(totalCoins.bottom, margin = Dp40)
-                },
+                }
+                .testTag(tag = stringResource(R.string.portfolio_card_today_profit_label)),
             text = stringResource(R.string.portfolio_card_today_profit_label),
             style = Style.lightSilverMedium16()
         )
@@ -75,7 +82,8 @@ fun PortfolioCard(
             modifier = Modifier
                 .constrainAs(todayProfit) {
                     top.linkTo(todayProfitLabel.bottom, margin = Dp8)
-                },
+                }
+                .testTag(tag = TestTagCardTodayProfit),
             // TODO: Remove dummy value when work on Integrate.
             text = stringResource(R.string.coin_currency, "193,280"),
             style = Style.whiteSemiBold24()
@@ -95,7 +103,7 @@ fun PortfolioCard(
 
 @Composable
 @Preview
-fun PortfolioCardPreview() {
+private fun PortfolioCardPreview() {
     ComposeTheme {
         PortfolioCard(
             modifier = Modifier

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
@@ -41,7 +41,7 @@ const val TestTagTrendingItemPriceChange = "TrendingItemPriceChange"
 @Suppress("LongMethod")
 @Composable
 fun TrendingItem(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     coinItem: CoinItemUiModel,
     onItemClick: () -> Unit
 ) {
@@ -125,7 +125,6 @@ fun TrendingItemPreview(
 ) {
     ComposeTheme {
         TrendingItem(
-            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )
@@ -139,7 +138,6 @@ fun TrendingItemPreviewDark(
 ) {
     ComposeTheme(darkTheme = true) {
         TrendingItem(
-            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )

--- a/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
+++ b/app/src/main/java/co/nimblehq/compose/crypto/ui/screens/home/TrendingItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -33,14 +34,20 @@ import co.nimblehq.compose.crypto.ui.theme.Style.textColor
 import co.nimblehq.compose.crypto.ui.uimodel.CoinItemUiModel
 import coil.compose.rememberAsyncImagePainter
 
+const val TestTagTrendingItemSymbol = "TrendingItemSymbol"
+const val TestTagTrendingItemCoinName = "TrendingItemCoinName"
+const val TestTagTrendingItemPriceChange = "TrendingItemPriceChange"
+
+@Suppress("LongMethod")
 @Composable
 fun TrendingItem(
+    modifier: Modifier,
     coinItem: CoinItemUiModel,
     onItemClick: () -> Unit
 ) {
 
     ConstraintLayout(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(Dp12))
             .clickable { onItemClick.invoke() }
@@ -76,7 +83,8 @@ fun TrendingItem(
                     top.linkTo(parent.top)
                     bottom.linkTo(coinName.top)
                     start.linkTo(anchor = logo.end, margin = Dp16)
-                },
+                }
+                .testTag(tag = TestTagTrendingItemSymbol),
             text = coinItem.symbol.uppercase(),
             color = MaterialTheme.colors.textColor,
             style = Style.semiBold16()
@@ -89,7 +97,8 @@ fun TrendingItem(
                     top.linkTo(coinSymbol.bottom)
                     bottom.linkTo(parent.bottom)
                     width = Dimension.preferredWrapContent
-                },
+                }
+                .testTag(tag = TestTagTrendingItemCoinName),
             text = coinItem.coinName,
             color = MaterialTheme.colors.coinNameColor,
             style = Style.medium14()
@@ -104,6 +113,7 @@ fun TrendingItem(
                     bottom.linkTo(coinName.bottom)
                     width = Dimension.preferredWrapContent
                 }
+                .testTag(tag = TestTagTrendingItemPriceChange)
         )
     }
 }
@@ -115,6 +125,7 @@ fun TrendingItemPreview(
 ) {
     ComposeTheme {
         TrendingItem(
+            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )
@@ -128,6 +139,7 @@ fun TrendingItemPreviewDark(
 ) {
     ComposeTheme(darkTheme = true) {
         TrendingItem(
+            modifier = Modifier,
             coinItem = coinItem,
             onItemClick = {}
         )

--- a/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreenTest.kt
@@ -1,0 +1,283 @@
+package co.nimblehq.compose.crypto.ui.screens.home
+
+import androidx.activity.compose.setContent
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.*
+import androidx.navigation.*
+import co.nimblehq.compose.crypto.R
+import co.nimblehq.compose.crypto.domain.usecase.GetMyCoinsUseCase
+import co.nimblehq.compose.crypto.domain.usecase.GetTrendingCoinsUseCase
+import co.nimblehq.compose.crypto.extension.toFormattedString
+import co.nimblehq.compose.crypto.test.MockUtil
+import co.nimblehq.compose.crypto.ui.navigation.AppDestination
+import co.nimblehq.compose.crypto.ui.screens.BaseViewModelTest
+import co.nimblehq.compose.crypto.ui.screens.MainActivity
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class HomeScreenTest : BaseViewModelTest() {
+
+    @get:Rule
+    val composeAndroidTestRule = createAndroidComposeRule<MainActivity>()
+
+    private val homeTitle: String
+        get() = composeAndroidTestRule.activity.getString(R.string.home_title)
+
+    private val totalCoinsLabel: String
+        get() = composeAndroidTestRule.activity.getString(R.string.portfolio_card_total_coin_label)
+
+    private val todayProfitLabel: String
+        get() = composeAndroidTestRule.activity.getString(R.string.portfolio_card_today_profit_label)
+
+    private val errorGeneric: String
+        get() = composeAndroidTestRule.activity.getString(R.string.error_generic)
+
+    private val mockGetMyCoinsUseCase = mockk<GetMyCoinsUseCase>()
+    private val mockGetTrendingCoinsUseCase = mockk<GetTrendingCoinsUseCase>()
+
+    private lateinit var viewModel: HomeViewModel
+
+    private var appDestination: AppDestination? = null
+
+    private val totalCoin = "7,273,291"
+    private val todayProfit = "193,280"
+
+    @Before
+    fun setUp() {
+        composeAndroidTestRule.activity.setContent {
+            HomeScreen(
+                viewModel = viewModel,
+                navigator = { destination -> appDestination = destination }
+            )
+        }
+    }
+
+    @Test
+    fun `When enter to HomeScreen, it render the PortfolioCard properly`() {
+        initViewModel()
+
+        with(composeAndroidTestRule) {
+            onNodeWithTag(testTag = homeTitle).assertTextEquals(homeTitle)
+            onNodeWithTag(testTag = totalCoinsLabel).assertTextEquals(totalCoinsLabel)
+            onNodeWithTag(testTag = todayProfitLabel).assertTextEquals(todayProfitLabel)
+            onNodeWithTag(testTag = TestTagCardTotalCoins).assertTextEquals(
+                activity.getString(R.string.coin_currency, totalCoin)
+            )
+            onNodeWithTag(testTag = TestTagCardTodayProfit).assertTextEquals(
+                activity.getString(R.string.coin_currency, todayProfit)
+            )
+        }
+    }
+
+    @Test
+    fun `When enter to HomeScreen and load MyCoins successfully, it render the UI properly`() {
+        every { mockGetMyCoinsUseCase.execute(any()) } returns flowOf(MockUtil.myCoins)
+
+        initViewModel()
+
+        with(composeAndroidTestRule) {
+            onNodeWithTag(testTag = TestTagCoinsLoader).assertIsDisplayed()
+
+            with(MockUtil.myCoins.first()) {
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemSymbol,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(symbol.uppercase())
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemCoinName,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(coinName)
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemPriceChange,
+                    useUnmergedTree = true
+                ).onFirst().onChild()
+                    .assertTextEquals(
+                        activity.getString(
+                            R.string.coin_profit_percent,
+                            priceChangePercentage24hInCurrency.toFormattedString()
+                        )
+                    )
+            }
+        }
+    }
+
+    @Test
+    fun `When enter to HomeScreen and load TrendingCoins successfully, it render the UI properly`() {
+        every { mockGetTrendingCoinsUseCase.execute(any()) } returns flowOf(MockUtil.trendingCoins)
+
+        initViewModel()
+
+        with(composeAndroidTestRule) {
+            onNodeWithTag(testTag = TestTagCoinsLoader).assertIsDisplayed()
+
+            with(MockUtil.trendingCoins.first()) {
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemSymbol,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(symbol.uppercase())
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemCoinName,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(coinName)
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemPriceChange,
+                    useUnmergedTree = true
+                ).onFirst().onChild()
+                    .assertTextEquals(
+                        activity.getString(
+                            R.string.coin_profit_percent,
+                            priceChangePercentage24hInCurrency.toFormattedString()
+                        )
+                    )
+            }
+        }
+    }
+
+    @Test
+    fun `When clicked on MyCoin item, it navigates to DetailScreen`() {
+        every { mockGetMyCoinsUseCase.execute(any()) } returns flowOf(MockUtil.myCoins)
+
+        initViewModel()
+
+        composeAndroidTestRule.onAllNodesWithTag(testTag = TestTagCoinItem).onFirst().performClick()
+
+        appDestination shouldBe AppDestination.CoinDetail
+    }
+
+    @Test
+    fun `When clicked on TrendingCoin item, it navigates to DetailScreen`() {
+        every { mockGetTrendingCoinsUseCase.execute(any()) } returns flowOf(MockUtil.trendingCoins)
+
+        initViewModel()
+
+        composeAndroidTestRule.onAllNodesWithTag(
+            testTag = TestTagTrendingItem
+        ).onFirst().performClick()
+
+        appDestination shouldBe AppDestination.CoinDetail
+    }
+
+    @Test
+    fun `When enter to HomeScreen and load MyCoins failed, it shows the Toast properly`() {
+        every { mockGetMyCoinsUseCase.execute(any()) } returns flow {
+            throw Throwable(errorGeneric)
+        }
+
+        initViewModel()
+
+        composeAndroidTestRule.onNodeWithTag(
+            testTag = TestTagCoinItem,
+            useUnmergedTree = true
+        ).assertDoesNotExist()
+
+        ShadowToast.getTextOfLatestToast() shouldBe errorGeneric
+    }
+
+    @Test
+    fun `When enter to HomeScreen and load TrendingCoins failed, it shows the Toast properly`() {
+        every { mockGetTrendingCoinsUseCase.execute(any()) } returns flow {
+            throw Throwable(errorGeneric)
+        }
+
+        initViewModel()
+
+        composeAndroidTestRule.onNodeWithTag(
+            testTag = TestTagTrendingItem,
+            useUnmergedTree = true
+        ).assertDoesNotExist()
+
+        ShadowToast.getTextOfLatestToast() shouldBe errorGeneric
+    }
+
+    @Test
+    fun `When pulled to refresh and load MyCoins successfully, it render the UI properly`() {
+        every { mockGetMyCoinsUseCase.execute(any()) } returns flowOf(MockUtil.myCoins)
+
+        initViewModel()
+
+        with(composeAndroidTestRule) {
+            onRoot().performTouchInput { swipeDown() }
+
+            with(MockUtil.myCoins.first()) {
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemSymbol,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(symbol.uppercase())
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemCoinName,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(coinName)
+                onAllNodesWithTag(
+                    testTag = TestTagCoinItemPriceChange,
+                    useUnmergedTree = true
+                ).onFirst().onChild()
+                    .assertTextEquals(
+                        activity.getString(
+                            R.string.coin_profit_percent,
+                            priceChangePercentage24hInCurrency.toFormattedString()
+                        )
+                    )
+            }
+        }
+
+        verify(exactly = 2) { mockGetMyCoinsUseCase.execute(any()) }
+    }
+
+    @Test
+    fun `When pulled to refresh and load TrendingCoins successfully, it render the UI properly`() {
+        every { mockGetTrendingCoinsUseCase.execute(any()) } returns flowOf(MockUtil.trendingCoins)
+
+        initViewModel()
+
+        with(composeAndroidTestRule) {
+            onNodeWithTag(testTag = TestTagCoinsLoader).assertIsDisplayed()
+
+            with(MockUtil.trendingCoins.first()) {
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemSymbol,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(symbol.uppercase())
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemCoinName,
+                    useUnmergedTree = true
+                ).onFirst().assertTextEquals(coinName)
+                onAllNodesWithTag(
+                    testTag = TestTagTrendingItemPriceChange,
+                    useUnmergedTree = true
+                ).onFirst().onChild()
+                    .assertTextEquals(
+                        activity.getString(
+                            R.string.coin_profit_percent,
+                            priceChangePercentage24hInCurrency.toFormattedString()
+                        )
+                    )
+            }
+
+            onRoot().performTouchInput { swipeDown() }
+        }
+
+        verify(exactly = 5) { mockGetTrendingCoinsUseCase.execute(any()) }
+    }
+
+    private fun initViewModel() {
+        viewModel = HomeViewModel(
+            dispatchers = testDispatcherProvider,
+            getMyCoinsUseCase = mockGetMyCoinsUseCase,
+            getTrendingCoinsUseCase = mockGetTrendingCoinsUseCase
+        )
+    }
+}

--- a/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreenTest.kt
+++ b/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeScreenTest.kt
@@ -46,15 +46,18 @@ class HomeScreenTest : BaseViewModelTest() {
     private val errorGeneric: String
         get() = composeAndroidTestRule.activity.getString(R.string.error_generic)
 
+    private val expectedPriceChange: String
+        get() = composeAndroidTestRule.activity.getString(
+            R.string.coin_profit_percent,
+            MockUtil.trendingCoins.first().priceChangePercentage24hInCurrency.toFormattedString()
+        )
+
     private val mockGetMyCoinsUseCase = mockk<GetMyCoinsUseCase>()
     private val mockGetTrendingCoinsUseCase = mockk<GetTrendingCoinsUseCase>()
 
     private lateinit var viewModel: HomeViewModel
 
     private var appDestination: AppDestination? = null
-
-    private val totalCoin = "7,273,291"
-    private val todayProfit = "193,280"
 
     @Before
     fun setUp() {
@@ -71,15 +74,11 @@ class HomeScreenTest : BaseViewModelTest() {
         initViewModel()
 
         with(composeAndroidTestRule) {
-            onNodeWithTag(testTag = homeTitle).assertTextEquals(homeTitle)
-            onNodeWithTag(testTag = totalCoinsLabel).assertTextEquals(totalCoinsLabel)
-            onNodeWithTag(testTag = todayProfitLabel).assertTextEquals(todayProfitLabel)
-            onNodeWithTag(testTag = TestTagCardTotalCoins).assertTextEquals(
-                activity.getString(R.string.coin_currency, totalCoin)
-            )
-            onNodeWithTag(testTag = TestTagCardTodayProfit).assertTextEquals(
-                activity.getString(R.string.coin_currency, todayProfit)
-            )
+            onNodeWithTag(testTag = TestTagHomeTitle).assertTextEquals(homeTitle)
+            onNodeWithTag(testTag = TestTagTotalCoinsLabel).assertTextEquals(totalCoinsLabel)
+            onNodeWithTag(testTag = TestTagTodayCoinProfitLabel).assertTextEquals(todayProfitLabel)
+            onNodeWithTag(testTag = TestTagCardTotalCoins).assertTextEquals("$7,273,291")
+            onNodeWithTag(testTag = TestTagCardTodayProfit).assertTextEquals("$193,280")
         }
     }
 
@@ -97,20 +96,16 @@ class HomeScreenTest : BaseViewModelTest() {
                     testTag = TestTagCoinItemSymbol,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(symbol.uppercase())
+
                 onAllNodesWithTag(
                     testTag = TestTagCoinItemCoinName,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(coinName)
+
                 onAllNodesWithTag(
                     testTag = TestTagCoinItemPriceChange,
                     useUnmergedTree = true
-                ).onFirst().onChild()
-                    .assertTextEquals(
-                        activity.getString(
-                            R.string.coin_profit_percent,
-                            priceChangePercentage24hInCurrency.toFormattedString()
-                        )
-                    )
+                ).onFirst().onChild().assertTextEquals(expectedPriceChange)
             }
         }
     }
@@ -129,20 +124,16 @@ class HomeScreenTest : BaseViewModelTest() {
                     testTag = TestTagTrendingItemSymbol,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(symbol.uppercase())
+
                 onAllNodesWithTag(
                     testTag = TestTagTrendingItemCoinName,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(coinName)
+
                 onAllNodesWithTag(
                     testTag = TestTagTrendingItemPriceChange,
                     useUnmergedTree = true
-                ).onFirst().onChild()
-                    .assertTextEquals(
-                        activity.getString(
-                            R.string.coin_profit_percent,
-                            priceChangePercentage24hInCurrency.toFormattedString()
-                        )
-                    )
+                ).onFirst().onChild().assertTextEquals(expectedPriceChange)
             }
         }
     }
@@ -210,28 +201,24 @@ class HomeScreenTest : BaseViewModelTest() {
         initViewModel()
 
         with(composeAndroidTestRule) {
-            onRoot().performTouchInput { swipeDown() }
-
             with(MockUtil.myCoins.first()) {
                 onAllNodesWithTag(
                     testTag = TestTagCoinItemSymbol,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(symbol.uppercase())
+
                 onAllNodesWithTag(
                     testTag = TestTagCoinItemCoinName,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(coinName)
+
                 onAllNodesWithTag(
                     testTag = TestTagCoinItemPriceChange,
                     useUnmergedTree = true
-                ).onFirst().onChild()
-                    .assertTextEquals(
-                        activity.getString(
-                            R.string.coin_profit_percent,
-                            priceChangePercentage24hInCurrency.toFormattedString()
-                        )
-                    )
+                ).onFirst().onChild().assertTextEquals(expectedPriceChange)
             }
+
+            onRoot().performTouchInput { swipeDown() }
         }
 
         verify(exactly = 2) { mockGetMyCoinsUseCase.execute(any()) }
@@ -251,20 +238,16 @@ class HomeScreenTest : BaseViewModelTest() {
                     testTag = TestTagTrendingItemSymbol,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(symbol.uppercase())
+
                 onAllNodesWithTag(
                     testTag = TestTagTrendingItemCoinName,
                     useUnmergedTree = true
                 ).onFirst().assertTextEquals(coinName)
+
                 onAllNodesWithTag(
                     testTag = TestTagTrendingItemPriceChange,
                     useUnmergedTree = true
-                ).onFirst().onChild()
-                    .assertTextEquals(
-                        activity.getString(
-                            R.string.coin_profit_percent,
-                            priceChangePercentage24hInCurrency.toFormattedString()
-                        )
-                    )
+                ).onFirst().onChild().assertTextEquals(expectedPriceChange)
             }
 
             onRoot().performTouchInput { swipeDown() }

--- a/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModelTest.kt
+++ b/app/src/test/java/co/nimblehq/compose/crypto/ui/screens/home/HomeViewModelTest.kt
@@ -60,7 +60,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             val error = Throwable()
             every { mockGetMyCoinsUseCase.execute(any()) } returns flow { throw error }
 
-            viewModel.output.error.test {
+            viewModel.output.myCoinsError.test {
                 testDispatcher.resumeDispatcher()
                 expectMostRecentItem() shouldBe error
                 cancelAndIgnoreRemainingEvents()
@@ -88,7 +88,7 @@ class HomeViewModelTest : BaseViewModelTest() {
             val error = Throwable()
             every { mockGetTrendingCoinsUseCase.execute(any()) } returns flow { throw error }
 
-            viewModel.output.error.test {
+            viewModel.output.trendingCoinsError.test {
                 testDispatcher.resumeDispatcher()
                 expectMostRecentItem() shouldBe error
                 cancelAndIgnoreRemainingEvents()

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,5 @@
+# Similar to Galaxy Nexus device profile
+qualifiers=w360dp-h640dp-xhdpi
+# Workaround for issue https://github.com/robolectric/robolectric/issues/6593
+instrumentedPackages=androidx.loader.content
+sdk=30

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -51,6 +51,7 @@ object Versions {
     const val TEST_JUNIT_VERSION = "4.13.2"
     const val TEST_KOTEST_VERSION = "4.6.3"
     const val TEST_MOCKK_VERSION = "1.10.6"
+    const val TEST_ROBOLECTRIC_VERSION = "4.8.2"
     const val TEST_RUNNER_VERSION = "1.3.0"
     const val TEST_TURBINE_VERSION = "0.7.0"
 }


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-crypto/issues/69

## What happened 👀

Create `HomeScreen` as UnitTest by using `Robolectric`

## Insight 📝

- Add `testImplementation` `org.robolectric:robolectric:4.8.2` to use the Roborectric.
- Add `testOptions` to `includeAndroidResources` for UnitTest.
- Add `robolectric.properties` to simulate the device.
- Create `HomeScreenTest`.
- We will define `testTag` to allow modified element to be found in tests. For more info, Please have a look on [this](https://foso.github.io/Jetpack-Compose-Playground/general/testing/#testtags)
 - Separate the error stream for `getMyCoins` and `getTrendingCoins` as it can happen at the same time, Also it can happen whenever we `refresh` too,  So, I think it would be better to separate them out from the base one in `BaseViewModel` (**TBD**).

## Proof Of Work 📹

https://user-images.githubusercontent.com/28002315/211766567-15c2244b-5250-404e-8dec-ddd072c54ea6.mov
