### PR TITLE
[#72] Migrate workflows setup-ruby action

### DIFF
--- a/.github/workflows/review_pull_request.yml
+++ b/.github/workflows/review_pull_request.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew jacocoTestReport
 
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
 


### PR DESCRIPTION
https://github.com/nimblehq/jetpack-compose-crypto/issues/72

## What happened 👀

![Screen Shot 2566-01-12 at 14 19 00](https://user-images.githubusercontent.com/28002315/212002400-26cdbc6f-b122-47b3-a745-12f58716d904.png)

The CI failed on step `Set up Ruby` because the current action is `deprecated` and is `no longer maintained.`

## Insight 📝

We must migrate `action` from `actions/setup-ruby@v1` to `ruby/setup-ruby@v1`. For more info https://github.com/actions/setup-ruby

## Proof Of Work 📹

![Screen Shot 2566-01-13 at 09 58 50](https://user-images.githubusercontent.com/28002315/212227141-49810d36-d342-419b-a33e-f4224eba11c1.png)


